### PR TITLE
Don't be so paranoid about TMP variables

### DIFF
--- a/src/boxFunctions/boxTransformBy.ts
+++ b/src/boxFunctions/boxTransformBy.ts
@@ -1,11 +1,8 @@
 import { _arrayReset } from "../internal/_arrayReset";
-import { polylineAlloc } from "../polylineFunctions/polylineAlloc";
 import { polylineGetBounds } from "../polylineFunctions/polylineGetBounds";
 import { polylineTransformBy } from "../polylineFunctions/polylineTransformBy";
-import { IBox, IMat2d } from "../types";
+import { IBox, IMat2d, IPolyline } from "../types";
 import { boxAlloc } from "./boxAlloc";
-
-const TMP0 = polylineAlloc();
 
 /**
  * Compute the bounds of the image of this box after applying a 2D affine transformation.
@@ -21,8 +18,8 @@ const TMP0 = polylineAlloc();
  * @param out
  */
 export function boxTransformBy(box: IBox, mat: IMat2d, out = boxAlloc()) {
-  const poly = TMP0;
-  _arrayReset(poly, box.minX, box.minY, box.minX, box.maxY, box.maxX, box.maxY, box.maxX, box.minY);
-  polylineTransformBy(poly, mat, poly);
-  return polylineGetBounds(poly, out);
+  const tmp = [] as IPolyline;
+  _arrayReset(tmp, box.minX, box.minY, box.minX, box.maxY, box.maxX, box.maxY, box.maxX, box.minY);
+  polylineTransformBy(tmp, mat, tmp);
+  return polylineGetBounds(tmp, out);
 }

--- a/src/internal/_lineTransformByOrtho.ts
+++ b/src/internal/_lineTransformByOrtho.ts
@@ -1,12 +1,11 @@
+import { lineAlloc } from "../lineFunctions/lineAlloc";
 import { lineReset } from "../lineFunctions/lineReset";
 import { ILine, IMat2d, IRay } from "../types";
-import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
 
-const TMP0 = vecAlloc();
-export function _lineTransformByOrtho(ray: IRay, mat: IMat2d, out: ILine) {
-  const initial = vecReset(ray.x0, ray.y0, TMP0);
+export function _lineTransformByOrtho(ray: IRay, mat: IMat2d, out: ILine = lineAlloc()) {
+  const initial = vecReset(ray.x0, ray.y0);
   vecTransformBy(initial, mat, initial);
   return lineReset(initial.x, initial.y, mat.a * ray.dirX + mat.c * ray.dirY, mat.b * ray.dirX + mat.d * ray.dirY, out);
 }

--- a/src/internal/_lookAt.ts
+++ b/src/internal/_lookAt.ts
@@ -1,8 +1,9 @@
+import { lineAlloc } from "../lineFunctions/lineAlloc";
 import { lineReset } from "../lineFunctions/lineReset";
 import { ILine } from "../types";
 import { EPSILON_SQ } from "./const";
 
-export function _lookAt(x0: number, y0: number, x1: number, y1: number, out: ILine) {
+export function _lookAt(x0: number, y0: number, x1: number, y1: number, out: ILine = lineAlloc()) {
   const dx = x1 - x0;
   const dy = y1 - y0;
   const lenSq = dx * dx + dy * dy;

--- a/src/internal/_polylineIntersectIteratorHelper.ts
+++ b/src/internal/_polylineIntersectIteratorHelper.ts
@@ -5,19 +5,20 @@ import { polylineGetSegment } from "../polylineFunctions/polylineGetSegment";
 import { segmentAlloc } from "../segmentFunctions/segmentAlloc";
 import { IPointIntersectionResult, IPolyline, ISegment } from "../types";
 
-const TMP0 = segmentAlloc();
-const TMP1 = pointIntersectionResultAlloc();
 
 export function _polylineIntersectIteratorHelper<T>(
   poly: IPolyline,
   value: T,
   doIntersectSegment: (segment: ISegment, value: T, out: IPointIntersectionResult) => IPointIntersectionResult,
 ) {
+  const tmp0 = segmentAlloc();
+  const tmp1 = pointIntersectionResultAlloc();
+
   const allIntersections: IPointIntersectionResult[] = [];
   const numSegments = polylineGetNumSegments(poly);
   for (let i = 0; i < numSegments; i++) {
-    const segment = polylineGetSegment(poly, i, TMP0);
-    const out = doIntersectSegment(segment, value, TMP1);
+    const segment = polylineGetSegment(poly, i, tmp0);
+    const out = doIntersectSegment(segment, value, tmp1);
     if (out.exists) {
       allIntersections.push(pointIntersectionResultReset(true, out.x, out.y, i + out.t0, out.t1));
     }

--- a/src/lineFunctions/lineIntersectLine.ts
+++ b/src/lineFunctions/lineIntersectLine.ts
@@ -1,7 +1,7 @@
-import { EPSILON } from "../internal/const";
 import { _dot } from "../internal/_dot";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lineTransformByOrtho } from "../internal/_lineTransformByOrtho";
+import { EPSILON } from "../internal/const";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { pointIntersectionResultReset } from "../pointIntersectionResultFunctions/pointIntersectionResultReset";

--- a/src/lineFunctions/lineIntersectLine.ts
+++ b/src/lineFunctions/lineIntersectLine.ts
@@ -1,19 +1,12 @@
+import { EPSILON } from "../internal/const";
 import { _dot } from "../internal/_dot";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lineTransformByOrtho } from "../internal/_lineTransformByOrtho";
-import { EPSILON } from "../internal/const";
-import { mat2dAlloc } from "../mat2dFunctions/mat2dAlloc";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { pointIntersectionResultReset } from "../pointIntersectionResultFunctions/pointIntersectionResultReset";
 import { ILine } from "../types";
-import { vecAlloc } from "../vecFunctions/vecAlloc";
-import { lineAlloc } from "./lineAlloc";
 import { lineGetPointAt } from "./lineGetPointAt";
-
-const TMP0 = mat2dAlloc();
-const TMP1 = lineAlloc();
-const TMP2 = vecAlloc();
 
 /**
  * Computes the intersection point between the two given lines, if it exists.
@@ -41,8 +34,8 @@ const TMP2 = vecAlloc();
  * @see {@link lineIntersectSegment}
  */
 export function lineIntersectLine(a: ILine, b: ILine, out = pointIntersectionResultAlloc()) {
-  const transform = mat2dReset(a.dirX, -a.dirY, a.dirY, a.dirX, -a.x0, -a.y0, TMP0);
-  const localB = _lineTransformByOrtho(b, transform, TMP1);
+  const transform = mat2dReset(a.dirX, -a.dirY, a.dirY, a.dirX, -a.x0, -a.y0);
+  const localB = _lineTransformByOrtho(b, transform);
   const isParallel = Math.abs(localB.dirY) < EPSILON;
 
   if (isParallel && Math.abs(localB.y0) < EPSILON) {
@@ -51,7 +44,7 @@ export function lineIntersectLine(a: ILine, b: ILine, out = pointIntersectionRes
     return _intersectionDNE(out);
   } else {
     const t0 = localB.x0 - (localB.dirX / localB.dirY) * localB.y0;
-    const intersectionPoint = lineGetPointAt(a, t0, TMP2);
+    const intersectionPoint = lineGetPointAt(a, t0);
     const t1 = _dot(b, intersectionPoint);
     return pointIntersectionResultReset(true, intersectionPoint.x, intersectionPoint.y, t0, t1, out);
   }

--- a/src/lineFunctions/lineIntersectSegment.ts
+++ b/src/lineFunctions/lineIntersectSegment.ts
@@ -3,10 +3,7 @@ import { _lookAt } from "../internal/_lookAt";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { segmentGetLength } from "../segmentFunctions/segmentGetLength";
 import { ILine, ISegment } from "../types";
-import { lineAlloc } from "./lineAlloc";
 import { lineIntersectLine } from "./lineIntersectLine";
-
-const TMP0 = lineAlloc();
 
 /**
  * Computes the intersection point between the given line and segment, if it exists.
@@ -37,7 +34,7 @@ const TMP0 = lineAlloc();
  */
 export function lineIntersectSegment(line: ILine, segment: ISegment, out = pointIntersectionResultAlloc()) {
   // TODO: https://github.com/crazytoucan/geometry/issues/1
-  const segmentLine = _lookAt(segment.x0, segment.y0, segment.x1, segment.y1, TMP0);
+  const segmentLine = _lookAt(segment.x0, segment.y0, segment.x1, segment.y1);
   const segmentLength = segmentGetLength(segment);
   lineIntersectLine(line, segmentLine, out);
   if (!out.exists || out.t1 < 0 || out.t1 > segmentLength) {

--- a/src/lineFunctions/lineTransformBy.ts
+++ b/src/lineFunctions/lineTransformBy.ts
@@ -1,12 +1,8 @@
 import { _lookAt } from "../internal/_lookAt";
 import { ILine, IMat2d } from "../types";
-import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
 import { lineAlloc } from "./lineAlloc";
-
-const TMP0 = vecAlloc();
-const TMP1 = vecAlloc();
 
 /**
  * Transforms a line by an affine matrix.
@@ -28,9 +24,9 @@ const TMP1 = vecAlloc();
  * @see {@link Imat2d}
  */
 export function lineTransformBy(line: ILine, mat: IMat2d, out = lineAlloc()) {
-  const p0 = vecReset(line.x0, line.y0, TMP0);
+  const p0 = vecReset(line.x0, line.y0);
   vecTransformBy(p0, mat, p0);
-  const p1 = vecReset(line.x0 + line.dirX, line.y0 + line.dirY, TMP1);
+  const p1 = vecReset(line.x0 + line.dirX, line.y0 + line.dirY);
   vecTransformBy(p1, mat, p1);
   return _lookAt(p0.x, p0.y, p1.x, p1.y, out);
 }

--- a/src/polygonFunctions/polygonGetSideLength.ts
+++ b/src/polygonFunctions/polygonGetSideLength.ts
@@ -1,9 +1,6 @@
-import { segmentAlloc } from "../segmentFunctions/segmentAlloc";
 import { segmentGetLength } from "../segmentFunctions/segmentGetLength";
 import { IPolygon } from "../types";
 import { polygonGetSideSegment } from "./polygonGetSideSegment";
-
-const TMP0 = segmentAlloc();
 
 /**
  * Returns the length of a polygon's side by index, starting at 0.
@@ -15,5 +12,5 @@ const TMP0 = segmentAlloc();
  * @param idx the side index to measure, starting at 0
  */
 export function polygonGetSideLength(poly: IPolygon, idx: number) {
-  return segmentGetLength(polygonGetSideSegment(poly, idx, TMP0));
+  return segmentGetLength(polygonGetSideSegment(poly, idx));
 }

--- a/src/polylineFunctions/polylineGetBounds.ts
+++ b/src/polylineFunctions/polylineGetBounds.ts
@@ -5,8 +5,6 @@ import { IPolyline } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
-const TMP0 = vecAlloc();
-
 /**
  * Computes bounding box of polyline's geometry
  *
@@ -14,9 +12,10 @@ const TMP0 = vecAlloc();
  * @param out
  */
 export function polylineGetBounds(poly: IPolyline, out = boxAlloc()) {
+  const tmp0 = vecAlloc();
   boxReset(Infinity, Infinity, -Infinity, -Infinity, out);
   for (let i = 0; i < poly.length; i += 2) {
-    const v0 = vecReset(poly[i], poly[i + 1], TMP0);
+    const v0 = vecReset(poly[i], poly[i + 1], tmp0);
     boxEncapsulate(out, v0, out);
   }
 

--- a/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
+++ b/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
@@ -6,8 +6,6 @@ import { IPolyline, IVec } from "../types";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetSegment } from "./polylineGetSegment";
 
-const TMP0 = segmentAlloc();
-const TMP2 = nearestPointResultAlloc();
 
 /**
  * Finds the closest the polyline comes to a given reference point.
@@ -25,12 +23,14 @@ const TMP2 = nearestPointResultAlloc();
  * @see {@link INearestPointResult}
  */
 export function polylineNearestDistanceSqToPoint(poly: IPolyline, point: IVec, out = nearestPointResultAlloc()) {
-  const winner = nearestPointResultReset(NaN, NaN, NaN, Infinity, out);
+  const tmp0 = segmentAlloc();
+  const tmp1 = nearestPointResultAlloc();
 
+  const winner = nearestPointResultReset(NaN, NaN, NaN, Infinity, out);
   const len = polylineGetNumSegments(poly);
   for (let i = 0; i < len; i++) {
-    const segment = polylineGetSegment(poly, i, TMP0);
-    const segmentNearest = segmentNearestDistanceSqToPoint(segment, point, TMP2);
+    const segment = polylineGetSegment(poly, i, tmp0);
+    const segmentNearest = segmentNearestDistanceSqToPoint(segment, point, tmp1);
     if (segmentNearest.distanceValue < winner.distanceValue) {
       nearestPointResultReset(
         segmentNearest.x,

--- a/src/polylineFunctions/polylineTransformBy.ts
+++ b/src/polylineFunctions/polylineTransformBy.ts
@@ -4,7 +4,6 @@ import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
 import { polylineAlloc } from "./polylineAlloc";
 
-const TMP0 = vecAlloc();
 
 /**
  * Transforms a polyline by an affine matrix.
@@ -20,12 +19,13 @@ const TMP0 = vecAlloc();
  * @see {@link Imat2d}
  */
 export function polylineTransformBy(poly: IPolyline, mat: IMat2d, out = polylineAlloc()) {
+  const tmp0 = vecAlloc();
   if (out.length !== poly.length) {
     out.length = poly.length;
   }
 
   for (let i = 0; i < poly.length; i += 2) {
-    const v0 = vecReset(poly[i], poly[i + 1], TMP0);
+    const v0 = vecReset(poly[i], poly[i + 1], tmp0);
     vecTransformBy(v0, mat, v0);
     out[i] = v0.x;
     out[i + 1] = v0.y;

--- a/src/polylineFunctions/polylineTrim.ts
+++ b/src/polylineFunctions/polylineTrim.ts
@@ -1,11 +1,8 @@
 import { _clamp } from "../internal/_clamp";
 import { IPolyline } from "../types";
-import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { polylineAlloc } from "./polylineAlloc";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetPointAt } from "./polylineGetPointAt";
-
-const TMP0 = vecAlloc();
 
 /**
  * Trims a polyline to a range of its _t_ parameter.
@@ -45,7 +42,7 @@ export function polylineTrim(poly: IPolyline, tStart: number, tEnd: number, out 
 
   out.length = 2 * (endCeil - startFloor + 1);
   let cursor = 0;
-  const beginPoint = polylineGetPointAt(poly, tStart, TMP0);
+  const beginPoint = polylineGetPointAt(poly, tStart);
   out[cursor++] = beginPoint.x;
   out[cursor++] = beginPoint.y;
 
@@ -54,7 +51,7 @@ export function polylineTrim(poly: IPolyline, tStart: number, tEnd: number, out 
     out[cursor++] = poly[2 * i + 1];
   }
 
-  const endPoint = polylineGetPointAt(poly, tEnd, TMP0);
+  const endPoint = polylineGetPointAt(poly, tEnd);
   out[cursor++] = endPoint.x;
   out[cursor++] = endPoint.y;
   return out;

--- a/src/rayFunctions/rayIntersectSegment.ts
+++ b/src/rayFunctions/rayIntersectSegment.ts
@@ -1,6 +1,6 @@
-import { EPSILON } from "../internal/const";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
+import { EPSILON } from "../internal/const";
 import { lineIntersectLine } from "../lineFunctions/lineIntersectLine";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { segmentGetLength } from "../segmentFunctions/segmentGetLength";

--- a/src/rayFunctions/rayIntersectSegment.ts
+++ b/src/rayFunctions/rayIntersectSegment.ts
@@ -1,13 +1,10 @@
+import { EPSILON } from "../internal/const";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
-import { EPSILON } from "../internal/const";
-import { lineAlloc } from "../lineFunctions/lineAlloc";
 import { lineIntersectLine } from "../lineFunctions/lineIntersectLine";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { segmentGetLength } from "../segmentFunctions/segmentGetLength";
 import { IRay, ISegment } from "../types";
-
-const TMP0 = lineAlloc();
 
 /**
  * Computes the intersection point between the ray and the segment, if it exists.
@@ -35,7 +32,7 @@ const TMP0 = lineAlloc();
  * @param out
  */
 export function rayIntersectSegment(ray: IRay, segment: ISegment, out = pointIntersectionResultAlloc()) {
-  const segmentRay = _lookAt(segment.x0, segment.y0, segment.x1, segment.y1, TMP0);
+  const segmentRay = _lookAt(segment.x0, segment.y0, segment.x1, segment.y1);
   lineIntersectLine(ray, segmentRay, out);
   const segmentLength = segmentGetLength(segment);
   if (out.exists && out.t0 > -EPSILON && out.t1 > -EPSILON && out.t1 < segmentLength + EPSILON) {

--- a/src/rayFunctions/rayNearestDistanceSqToPoint.ts
+++ b/src/rayFunctions/rayNearestDistanceSqToPoint.ts
@@ -1,12 +1,9 @@
 import { _dot } from "../internal/_dot";
 import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestPointResultAlloc";
-import { nearestPointResultReset } from '../nearestPointResultFunctions/nearestPointResultReset';
+import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
 import { IRay, IVec } from "../types";
-import { vecAlloc } from '../vecFunctions/vecAlloc';
-import { vecDistanceSq } from '../vecFunctions/vecDistanceSq';
+import { vecDistanceSq } from "../vecFunctions/vecDistanceSq";
 import { rayGetPointAt } from "./rayGetPointAt";
-
-const TMP0 = vecAlloc();
 
 /**
  * Determines the closest the ray comes to a given reference point
@@ -31,7 +28,7 @@ const TMP0 = vecAlloc();
  */
 export function rayNearestDistanceSqToPoint(ray: IRay, point: IVec, out = nearestPointResultAlloc()) {
   const t = Math.max(0, _dot(ray, point));
-  const closest = rayGetPointAt(ray, t, TMP0);
+  const closest = rayGetPointAt(ray, t);
   const distanceSq = vecDistanceSq(closest, point);
   return nearestPointResultReset(closest.x, closest.y, t, distanceSq, out);
 }

--- a/src/segmentFunctions/segmentIntersectSegment.ts
+++ b/src/segmentFunctions/segmentIntersectSegment.ts
@@ -1,6 +1,6 @@
-import { EPSILON } from "../internal/const";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
+import { EPSILON } from "../internal/const";
 import { lineIntersectSegment } from "../lineFunctions/lineIntersectSegment";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { ISegment } from "../types";

--- a/src/segmentFunctions/segmentIntersectSegment.ts
+++ b/src/segmentFunctions/segmentIntersectSegment.ts
@@ -1,13 +1,10 @@
+import { EPSILON } from "../internal/const";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
-import { EPSILON } from "../internal/const";
-import { lineAlloc } from "../lineFunctions/lineAlloc";
 import { lineIntersectSegment } from "../lineFunctions/lineIntersectSegment";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { ISegment } from "../types";
 import { segmentGetLength } from "./segmentGetLength";
-
-const TMP0 = lineAlloc();
 
 /**
  * Computes the intersection point between the two line segments, if it exists.
@@ -38,7 +35,7 @@ const TMP0 = lineAlloc();
  * @see {@link segmentIntersectRay}
  */
 export function segmentIntersectSegment(a: ISegment, b: ISegment, out = pointIntersectionResultAlloc()) {
-  const aLine = _lookAt(a.x0, a.y0, a.x1, a.y1, TMP0);
+  const aLine = _lookAt(a.x0, a.y0, a.x1, a.y1);
   lineIntersectSegment(aLine, b, out);
   const segmentLength = segmentGetLength(a);
   if (out.exists && out.t0 > -EPSILON && out.t0 < segmentLength + EPSILON) {

--- a/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
+++ b/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
@@ -1,5 +1,5 @@
-import { EPSILON_SQ } from "../internal/const";
 import { _lerp } from "../internal/_lerp";
+import { EPSILON_SQ } from "../internal/const";
 import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestPointResultAlloc";
 import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
 import { ISegment, IVec } from "../types";

--- a/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
+++ b/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
@@ -1,16 +1,12 @@
-import { _lerp } from "../internal/_lerp";
 import { EPSILON_SQ } from "../internal/const";
+import { _lerp } from "../internal/_lerp";
 import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestPointResultAlloc";
 import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
 import { ISegment, IVec } from "../types";
-import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecCross } from "../vecFunctions/vecCross";
 import { vecDot } from "../vecFunctions/vecDot";
 import { vecGetLengthSq } from "../vecFunctions/vecGetLengthSq";
 import { vecReset } from "../vecFunctions/vecReset";
-
-const TMP0 = vecAlloc();
-const TMP1 = vecAlloc();
 
 /**
  * Finds the closest the segment comes to a given reference point.
@@ -24,8 +20,8 @@ const TMP1 = vecAlloc();
  * @see {@link INearestPointResult}
  */
 export function segmentNearestDistanceSqToPoint(segment: ISegment, point: IVec, out = nearestPointResultAlloc()) {
-  const segVector = vecReset(segment.x1 - segment.x0, segment.y1 - segment.y0, TMP0);
-  const pointVector = vecReset(point.x - segment.x0, point.y - segment.y0, TMP1);
+  const segVector = vecReset(segment.x1 - segment.x0, segment.y1 - segment.y0);
+  const pointVector = vecReset(point.x - segment.x0, point.y - segment.y0);
 
   const segLengthSq = vecGetLengthSq(segVector);
   if (segLengthSq < EPSILON_SQ) {


### PR DESCRIPTION
An investigation into whether using static temp-variable memory for intermediate calculations is ultimately cheaper than letting the Chrome garbage collector manage allocations on the fly: https://jsperf.com/tmp-vs-local

In short, it seems that writing to globally-accessible memory incurs a "commit" cost. Chrome seems to be very good at releasing young-gen allocations.

