### PR TITLE
Add separate commonjs and ESM builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           root: '.'
           paths:
             - lib
+            - esm
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.DS_Store
-.vscode/
 *.log
-lib/
-node_modules/
+.DS_Store
+.vscode
+esm
+lib
+node_modules
 Thumbs.db

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
+!esm
 !lib
+esm/__test__
 lib/__test__

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "math2d",
   "version": "2.0.14",
+  "module": "./esm/index.js",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "yarn build:commonjs && yarn build:esm",
+    "build:commonjs": "tsc",
+    "build:esm": "tsc -p tsconfig-esm.json",
     "benchmarks": "tsc -p benchmarks && node benchmarks/lib/benchmarks/run.js",
     "lint": "tslint --project tsconfig.json",
     "docs": "scripts/generate-typedoc-data.sh",

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -7,12 +7,12 @@
       "dom",
       "es2015"
     ],
-    "module": "CommonJS",
+    "module": "ES2015",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "lib",
+    "outDir": "esm",
     "plugins": [{ "name": "typescript-tslint-plugin" }],
     "pretty": true,
     "removeComments": false,
@@ -21,7 +21,7 @@
     "strict": true,
     "stripInternal": true,
     "noFallthroughCasesInSwitch": true,
-    "target": "ES5"
+    "target": "ES2017"
   },
   "exclude": [
     "benchmarks",


### PR DESCRIPTION
Previously, Math2D was built only with ESM output. This PR additionally adds CJS output.

- ESM build will be under `"module"` package.json key
- CJS build will be under `"main"` package.json key

This is in line with expectations from other tools, like Webpack, which will prefer `"module"` when specified.