### PR TITLE
Modernize box tests (use test.each, etc.)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   transformIgnorePatterns: ["/node_modules/(?!(lodash-es|@foundry|@workshop|@palantir|@acme|@gotham|@tron)/)"],
   globals: {
     "ts-jest": {
-      tsConfigFile: "tsconfig.jest.json",
+      tsconfig: "tsconfig.jest.json",
     },
   },
   verbose: true,

--- a/src/__test__/boxFunctions/boxAlloc.spec.ts
+++ b/src/__test__/boxFunctions/boxAlloc.spec.ts
@@ -1,25 +1,10 @@
 import { boxAlloc } from "../../boxFunctions/boxAlloc";
-import { IBox } from "../../types";
 
-describe("boxAlloc", () => {
-  let box: IBox;
-  beforeAll(() => {
-    box = boxAlloc();
-  });
-
-  it("minX NaN", () => {
-    expect(box.minX).toBeNaN();
-  });
-
-  it("minY NaN", () => {
-    expect(box.minY).toBeNaN();
-  });
-
-  it("maxX NaN", () => {
-    expect(box.maxX).toBeNaN();
-  });
-
-  it("maxY NaN", () => {
-    expect(box.maxY).toBeNaN();
+it("boxAlloc", () => {
+  expect(boxAlloc()).toEqual({
+    minX: NaN,
+    minY: NaN,
+    maxX: NaN,
+    maxY: NaN,
   });
 });

--- a/src/__test__/boxFunctions/boxClone.spec.ts
+++ b/src/__test__/boxFunctions/boxClone.spec.ts
@@ -4,17 +4,17 @@ import { boxReset } from "../../boxFunctions/boxReset";
 import { expectBoxEqualsApprox } from "../helpers";
 
 describe("boxClone", () => {
-  it("should copy components", () => {
+  it("copies components", () => {
     expectBoxEqualsApprox(boxClone(boxReset(4, 5, 6, 7)), 4, 5, 6, 7);
   });
 
-  it("should return a new box if no `out`", () => {
+  it("returns a new box if no `out`", () => {
     const box = boxReset(4, 5, 6, 7);
     const res = boxClone(box);
     expect(res).not.toBe(box);
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = boxAlloc();
     const res = boxClone(boxReset(4, 5, 6, 7), out);
     expect(res).toBe(out);

--- a/src/__test__/boxFunctions/boxClone.spec.ts
+++ b/src/__test__/boxFunctions/boxClone.spec.ts
@@ -1,22 +1,19 @@
 import { boxAlloc } from "../../boxFunctions/boxAlloc";
 import { boxClone } from "../../boxFunctions/boxClone";
 import { boxReset } from "../../boxFunctions/boxReset";
-import { expectBoxEqualsApprox } from "../helpers";
 
 describe("boxClone", () => {
   it("copies components", () => {
-    expectBoxEqualsApprox(boxClone(boxReset(4, 5, 6, 7)), 4, 5, 6, 7);
+    expect(boxClone(boxReset(4, 5, 6, 7))).toEqual(boxReset(4, 5, 6, 7));
   });
 
   it("returns a new box if no `out`", () => {
     const box = boxReset(4, 5, 6, 7);
-    const res = boxClone(box);
-    expect(res).not.toBe(box);
+    expect(boxClone(box)).not.toBe(box);
   });
 
   it("returns `out` if given", () => {
     const out = boxAlloc();
-    const res = boxClone(boxReset(4, 5, 6, 7), out);
-    expect(res).toBe(out);
+    expect(boxClone(boxReset(4, 5, 6, 7), out)).toBe(out);
   });
 });

--- a/src/__test__/boxFunctions/boxContainsBox.spec.ts
+++ b/src/__test__/boxFunctions/boxContainsBox.spec.ts
@@ -1,32 +1,16 @@
 import { boxContainsBox } from "../../boxFunctions/boxContainsBox";
-import { boxReset } from "../../boxFunctions/boxReset";
+import { _box } from "../helpers";
 
 describe("boxContainsBox", () => {
-  it("[-1 -1 +1 +1] ⊇ [-1 -1 +1 +1] => true", () => {
-    expect(boxContainsBox(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 1))).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⊇ [-1 -1 +1 +2] => false", () => {
-    expect(boxContainsBox(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 2))).toBe(false);
-  });
-
-  it("[-1 -1 +1 +1] ⊇ [0 0 0 0] => true", () => {
-    expect(boxContainsBox(boxReset(-1, -1, 1, 1), boxReset(0, 0, 0, 0))).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⊇ [-0.5 -0.5 +0.5 +0.5] => true", () => {
-    expect(boxContainsBox(boxReset(-1, -1, 1, 1), boxReset(-0.5, -0.5, 0.5, 0.5))).toBe(true);
-  });
-
-  it("[-∞ -∞ +∞ +∞] ⊇ [-0.5 -0.5 +0.5 +0.5] => true", () => {
-    expect(boxContainsBox(boxReset(-Infinity, -Infinity, Infinity, Infinity), boxReset(-0.5, -0.5, 0.5, 0.5))).toBe(
-      true,
-    );
-  });
-
-  it("[∞ ∞ -∞ -∞] ⊇ [-0.5 -0.5 +0.5 +0.5] => false", () => {
-    expect(boxContainsBox(boxReset(Infinity, Infinity, -Infinity, -Infinity), boxReset(-0.5, -0.5, 0.5, 0.5))).toBe(
-      false,
-    );
+  it.each`
+    a                                             | b                         | result
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 1]}         | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 2]}         | ${false}
+    ${[-1, -1, 1, 1]}                             | ${[0, 0, 0, 0]}           | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[-0.5, -0.5, 0.5, 0.5]} | ${true}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${true}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${false}
+  `("$a $b => $result", ({ a, b, result }) => {
+    expect(boxContainsBox(_box(a), _box(b))).toBe(result);
   });
 });

--- a/src/__test__/boxFunctions/boxContainsPoint.spec.ts
+++ b/src/__test__/boxFunctions/boxContainsPoint.spec.ts
@@ -1,38 +1,18 @@
 import { boxContainsPoint } from "../../boxFunctions/boxContainsPoint";
-import { boxReset } from "../../boxFunctions/boxReset";
 import { IntervalMode } from "../../const";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _box, _vec } from "../helpers";
 
 describe("boxContainsPoint", () => {
-  it("[-1 -1 +1 +1] ∋ (0, 0) => true", () => {
-    expect(boxContainsPoint(boxReset(-1, -1, 1, 1), vecReset(0, 0), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ∋ (1, 0) => true", () => {
-    expect(boxContainsPoint(boxReset(-1, -1, 1, 1), vecReset(1, 0), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ∋ (0, -2) => false", () => {
-    expect(boxContainsPoint(boxReset(-1, -1, 1, 1), vecReset(0, -2), IntervalMode.CLOSED)).toBe(false);
-  });
-
-  it("[-1 -1 +1 +1] ∋ (-2, -3) => false", () => {
-    expect(boxContainsPoint(boxReset(-1, -1, 1, 1), vecReset(-2, -3), IntervalMode.CLOSED)).toBe(false);
-  });
-
-  it("[-1 -1 +1 +1] ∋ (NaN, NaN) => false", () => {
-    expect(boxContainsPoint(boxReset(-1, -1, 1, 1), vecReset(NaN, NaN), IntervalMode.CLOSED)).toBe(false);
-  });
-
-  it("[-∞ -∞ +∞ +∞] ∋ (1, 1) => true", () => {
-    expect(
-      boxContainsPoint(boxReset(-Infinity, -Infinity, Infinity, Infinity), vecReset(1, 1), IntervalMode.CLOSED),
-    ).toBe(true);
-  });
-
-  it("[+∞ +∞ -∞ -∞] ∋ (1, 1) => true", () => {
-    expect(
-      boxContainsPoint(boxReset(Infinity, Infinity, -Infinity, -Infinity), vecReset(1, 1), IntervalMode.CLOSED),
-    ).toBe(false);
+  it.each`
+    box                                           | point         | imode                  | result
+    ${[-1, -1, 1, 1]}                             | ${[0, 0]}     | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[1, 0]}     | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[0, -2]}    | ${IntervalMode.CLOSED} | ${false}
+    ${[-1, -1, 1, 1]}                             | ${[-2, -3]}   | ${IntervalMode.CLOSED} | ${false}
+    ${[-1, -1, 1, 1]}                             | ${[NaN, NaN]} | ${IntervalMode.CLOSED} | ${false}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[1, 1]}     | ${IntervalMode.CLOSED} | ${true}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[1, 1]}     | ${IntervalMode.CLOSED} | ${false}
+  `("$box $point $imode => $result", ({ box, point, imode, result }) => {
+    expect(boxContainsPoint(_box(box), _vec(point), imode)).toBe(result);
   });
 });

--- a/src/__test__/boxFunctions/boxEncapsulate.spec.ts
+++ b/src/__test__/boxFunctions/boxEncapsulate.spec.ts
@@ -1,5 +1,5 @@
 import { boxEncapsulate } from "../../boxFunctions/boxEncapsulate";
-import { expectBoxEqualsApprox2, _box, _vec } from "../helpers";
+import { expectBoxEqualsApprox, _box, _vec } from "../helpers";
 
 describe("boxEncapsulate", () => {
   it.each`
@@ -11,6 +11,6 @@ describe("boxEncapsulate", () => {
     ${[-1, -1, 1, 1]} | ${[-2, 4]}    | ${[-2, -1, 1, 4]}
     ${[-1, -1, 1, 1]} | ${[NaN, NaN]} | ${[NaN, NaN, NaN, NaN]}
   `("$box $point => $result", ({ box, point, result }) => {
-    expectBoxEqualsApprox2(boxEncapsulate(_box(box), _vec(point)), _box(result));
+    expectBoxEqualsApprox(boxEncapsulate(_box(box), _vec(point)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxEncapsulate.spec.ts
+++ b/src/__test__/boxFunctions/boxEncapsulate.spec.ts
@@ -1,30 +1,16 @@
 import { boxEncapsulate } from "../../boxFunctions/boxEncapsulate";
-import { boxReset } from "../../boxFunctions/boxReset";
-import { vecReset } from "../../vecFunctions/vecReset";
-import { expectBoxEqualsApprox } from "../helpers";
+import { expectBoxEqualsApprox2, _box, _vec } from "../helpers";
 
 describe("boxEncapsulate", () => {
-  it("[-1 -1 +1 +1], (0,0) => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(0, 0)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1], (1,0) => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(1, 0)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1], (0,-2) => [-1 -2 +1 +1]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(0, -2)), -1, -2, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1], (-2,-3) => [-2 -3 +1 +1]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(-2, -3)), -2, -3, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1], (-2,4) => [-2 -1 +1 +4]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(-2, 4)), -2, -1, 1, 4);
-  });
-
-  it("[-1 -1 +1 +1], (NaN,NaN) => [NaN NaN NaN NaN]", () => {
-    expectBoxEqualsApprox(boxEncapsulate(boxReset(-1, -1, 1, 1), vecReset(NaN, NaN)), NaN, NaN, NaN, NaN);
+  it.each`
+    box               | point         | result
+    ${[-1, -1, 1, 1]} | ${[0, 0]}     | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]} | ${[1, 0]}     | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]} | ${[0, -2]}    | ${[-1, -2, 1, 1]}
+    ${[-1, -1, 1, 1]} | ${[-2, -3]}   | ${[-2, -3, 1, 1]}
+    ${[-1, -1, 1, 1]} | ${[-2, 4]}    | ${[-2, -1, 1, 4]}
+    ${[-1, -1, 1, 1]} | ${[NaN, NaN]} | ${[NaN, NaN, NaN, NaN]}
+  `("$box $point => $result", ({ box, point, result }) => {
+    expectBoxEqualsApprox2(boxEncapsulate(_box(box), _vec(point)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxEnclosingPoints.spec.ts
+++ b/src/__test__/boxFunctions/boxEnclosingPoints.spec.ts
@@ -1,7 +1,8 @@
 import { boxAlloc } from "../../boxFunctions/boxAlloc";
 import { boxEnclosingPoints } from "../../boxFunctions/boxEnclosingPoints";
+import { boxReset } from "../../boxFunctions/boxReset";
 import { vecReset } from "../../vecFunctions/vecReset";
-import { expectBoxEqualsApprox, expectBoxEqualsApprox2, _box, _vec } from "../helpers";
+import { expectBoxEqualsApprox, _box, _vec } from "../helpers";
 
 describe("boxEnclosingPoints", () => {
   it.each`
@@ -15,12 +16,12 @@ describe("boxEnclosingPoints", () => {
     ${[[NaN, NaN], [-1, -2], [2, -1], [-2, 1]]} | ${[-2, -2, 2, 1]}
     ${[[-3, NaN], [-1, -2], [2, -1], [-2, 1]]}  | ${[-3, -2, 2, 1]}
   `("$points => $result", ({ points, result }) => {
-    expectBoxEqualsApprox2(boxEnclosingPoints(points.map(_vec)), _box(result));
+    expectBoxEqualsApprox(boxEnclosingPoints(points.map(_vec)), _box(result));
   });
 
   it("updates an `out` box if provided", () => {
     const out = boxAlloc();
     boxEnclosingPoints([vecReset(1, 2)], out);
-    expectBoxEqualsApprox(out, 1, 2, 1, 2);
+    expectBoxEqualsApprox(out, boxReset(1, 2, 1, 2));
   });
 });

--- a/src/__test__/boxFunctions/boxEnclosingPoints.spec.ts
+++ b/src/__test__/boxFunctions/boxEnclosingPoints.spec.ts
@@ -1,39 +1,21 @@
 import { boxAlloc } from "../../boxFunctions/boxAlloc";
 import { boxEnclosingPoints } from "../../boxFunctions/boxEnclosingPoints";
 import { vecReset } from "../../vecFunctions/vecReset";
-import { expectBoxEqualsApprox } from "../helpers";
+import { expectBoxEqualsApprox, expectBoxEqualsApprox2, _box, _vec } from "../helpers";
 
 describe("boxEnclosingPoints", () => {
-  it("no points => [Infinity, Infinity, -Infinity, -Infinity]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([]), Infinity, Infinity, -Infinity, -Infinity);
-  });
-
-  it("(NaN, NaN) => [Infinity, Infinity, -Infinity, -Infinity]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(NaN, NaN)]), Infinity, Infinity, -Infinity, -Infinity);
-  });
-
-  it("(1, 2) => [1 2 1 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(1, 2)]), 1, 2, 1, 2);
-  });
-
-  it("(1, 2), (-1, -2) => [-1 -2 1 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(1, 2), vecReset(-1, -2)]), -1, -2, 1, 2);
-  });
-
-  it("(1, 2), (-1, -2), (2, -1) => [-1 -2 2 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(1, 2), vecReset(-1, -2), vecReset(2, -1)]), -1, -2, 2, 2);
-  });
-
-  it("(1, 2), (-1, -2), (2, -1), (-2, 1) => [-2 -2 2 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(1, 2), vecReset(-1, -2), vecReset(2, -1), vecReset(-2, 1)]), -2, -2, 2, 2);
-  });
-
-  it("(NaN, NaN), (-1, -2), (2, -1), (-2, 1) => [-2 -2 2 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(NaN, NaN), vecReset(-1, -2), vecReset(2, -1), vecReset(-2, 1)]), -2, -2, 2, 1);
-  });
-
-  it("(-3, NaN), (-1, -2), (2, -1), (-2, 1) => [-2 -2 2 2]", () => {
-    expectBoxEqualsApprox(boxEnclosingPoints([vecReset(-3, NaN), vecReset(-1, -2), vecReset(2, -1), vecReset(-2, 1)]), -3, -2, 2, 1);
+  it.each`
+    points                                      | result
+    ${[]}                                       | ${[Infinity, Infinity, -Infinity, -Infinity]}
+    ${[[NaN, NaN]]}                             | ${[Infinity, Infinity, -Infinity, -Infinity]}
+    ${[[1, 2]]}                                 | ${[1, 2, 1, 2]}
+    ${[[1, 2], [-1, -2]]}                       | ${[-1, -2, 1, 2]}
+    ${[[1, 2], [-1, -2], [2, -1]]}              | ${[-1, -2, 2, 2]}
+    ${[[1, 2], [-1, -2], [2, -1], [-2, 1]]}     | ${[-2, -2, 2, 2]}
+    ${[[NaN, NaN], [-1, -2], [2, -1], [-2, 1]]} | ${[-2, -2, 2, 1]}
+    ${[[-3, NaN], [-1, -2], [2, -1], [-2, 1]]}  | ${[-3, -2, 2, 1]}
+  `("$points => $result", ({ points, result }) => {
+    expectBoxEqualsApprox2(boxEnclosingPoints(points.map(_vec)), _box(result));
   });
 
   it("updates an `out` box if provided", () => {

--- a/src/__test__/boxFunctions/boxGetOutCode.spec.ts
+++ b/src/__test__/boxFunctions/boxGetOutCode.spec.ts
@@ -1,39 +1,20 @@
 // tslint:disable:no-bitwise
 import { boxGetOutCode } from "../../boxFunctions/boxGetOutCode";
-import { boxReset } from "../../boxFunctions/boxReset";
 import { Out } from "../../const";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _box, _vec } from "../helpers";
 
-describe("boxGetOutCode", () => {
-  it("[-1 -1 +1 +1], (0,2) => Out.MAX_Y", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(0, 2))).toBe(Out.MAX_Y);
-  });
-
-  it("[-1 -1 +1 +1], (0,-2) => Out.MIN_Y", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(0, -2))).toBe(Out.MIN_Y);
-  });
-
-  it("[-1 -1 +1 +1], (-2,0) => Out.MIN_X", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(-2, 0))).toBe(Out.MIN_X);
-  });
-
-  it("[-1 -1 +1 +1], (2,0) => Out.MIN_X", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(2, 0))).toBe(Out.MAX_X);
-  });
-
-  it("[-1 -1 +1 +1], (-3,3) => Out.MIN_X | Out.MAX_Y", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(-3, 3))).toBe(Out.MIN_X | Out.MAX_Y);
-  });
-
-  it("[-1 -1 +1 +1], (-1,0) => 0", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(-1, 0))).toBe(0);
-  });
-
-  it("[-1 -1 +1 +1], (1,0) => 0", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(1, 0))).toBe(0);
-  });
-
-  it("[-1 -1 +1 +1], (0,0) => 0", () => {
-    expect(boxGetOutCode(boxReset(-1, -1, 1, 1), vecReset(0, 0))).toBe(0);
+describe(`boxGetOutCode [MIN_X=${Out.MIN_X}, MAX_X=${Out.MAX_X}, MIN_Y=${Out.MIN_Y}, MAX_Y=${Out.MAX_Y}]`, () => {
+  it.each`
+    box               | vec        | result
+    ${[-1, -1, 1, 1]} | ${[0, 2]}  | ${Out.MAX_Y}
+    ${[-1, -1, 1, 1]} | ${[0, -2]} | ${Out.MIN_Y}
+    ${[-1, -1, 1, 1]} | ${[-2, 0]} | ${Out.MIN_X}
+    ${[-1, -1, 1, 1]} | ${[2, 0]}  | ${Out.MAX_X}
+    ${[-1, -1, 1, 1]} | ${[-3, 3]} | ${Out.MIN_X | Out.MAX_Y}
+    ${[-1, -1, 1, 1]} | ${[-1, 0]} | ${0}
+    ${[-1, -1, 1, 1]} | ${[1, 0]}  | ${0}
+    ${[-1, -1, 1, 1]} | ${[0, 0]}  | ${0}
+  `("$box $vec => $result", ({ box, vec, result }) => {
+    expect(boxGetOutCode(_box(box), _vec(vec))).toBe(result);
   });
 });

--- a/src/__test__/boxFunctions/boxIntersection.spec.ts
+++ b/src/__test__/boxFunctions/boxIntersection.spec.ts
@@ -1,5 +1,5 @@
 import { boxIntersection } from "../../boxFunctions/boxIntersection";
-import { expectBoxEqualsApprox2, _box } from "../helpers";
+import { expectBoxEqualsApprox, _box } from "../helpers";
 
 describe("boxIntersection", () => {
   it.each`
@@ -12,6 +12,6 @@ describe("boxIntersection", () => {
     ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-0.5, -0.5, 0.5, 0.5]}
     ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[Infinity, Infinity, -Infinity, -Infinity]}
   `("$a $b => $result", ({ a, b, result }) => {
-    expectBoxEqualsApprox2(boxIntersection(_box(a), _box(b)), _box(result));
+    expectBoxEqualsApprox(boxIntersection(_box(a), _box(b)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxIntersection.spec.ts
+++ b/src/__test__/boxFunctions/boxIntersection.spec.ts
@@ -1,51 +1,17 @@
 import { boxIntersection } from "../../boxFunctions/boxIntersection";
-import { boxReset } from "../../boxFunctions/boxReset";
-import { expectBoxEqualsApprox } from "../helpers";
+import { expectBoxEqualsApprox2, _box } from "../helpers";
 
 describe("boxIntersection", () => {
-  it("[-1 -1 +1 +1] ⋂ [-1 -1 +1 +1] => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxIntersection(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 1)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1] ⋂ [-1 -1 +1 +2] => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxIntersection(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 2)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1] ⋂ [0 0 0 0] => [0 0 0 0]", () => {
-    expectBoxEqualsApprox(boxIntersection(boxReset(-1, -1, 1, 1), boxReset(0, 0, 0, 0)), 0, 0, 0, 0);
-  });
-
-  it("[-1 -1 +1 +1] ⋂ [-0.5 -0.5 +0.5 +0.5] => true", () => {
-    expectBoxEqualsApprox(
-      boxIntersection(boxReset(-1, -1, 1, 1), boxReset(-0.5, -0.5, 0.5, 0.5)),
-      -0.5,
-      -0.5,
-      0.5,
-      0.5,
-    );
-  });
-
-  it("[-1 -1 +1 +1] ⋂ [+3 -1 +5 +1] => [+3 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxIntersection(boxReset(-1, -1, 1, 1), boxReset(3, -1, 5, 1)), 3, -1, 1, 1);
-  });
-
-  it("[-∞ -∞ +∞ +∞] ⋂ [-0.5 -0.5 +0.5 +0.5] => [-0.5 -0.5 +0.5 +0.5]", () => {
-    expectBoxEqualsApprox(
-      boxIntersection(boxReset(-Infinity, -Infinity, Infinity, Infinity), boxReset(-0.5, -0.5, 0.5, 0.5)),
-      -0.5,
-      -0.5,
-      0.5,
-      0.5,
-    );
-  });
-
-  it("[+∞ +∞ -∞ -∞] ⋂ [-0.5 -0.5 +0.5 +0.5] => [+∞ +∞ -∞ -∞]", () => {
-    expectBoxEqualsApprox(
-      boxIntersection(boxReset(Infinity, Infinity, -Infinity, -Infinity), boxReset(-0.5, -0.5, 0.5, 0.5)),
-      Infinity,
-      Infinity,
-      -Infinity,
-      -Infinity,
-    );
+  it.each`
+    a                                             | b                         | result
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 1]}         | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 2]}         | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]}                             | ${[0, 0, 0, 0]}           | ${[0, 0, 0, 0]}
+    ${[-1, -1, 1, 1]}                             | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-0.5, -0.5, 0.5, 0.5]}
+    ${[-1, -1, 1, 1]}                             | ${[3, -1, 5, 1]}          | ${[3, -1, 1, 1]}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-0.5, -0.5, 0.5, 0.5]}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[Infinity, Infinity, -Infinity, -Infinity]}
+  `("$a $b => $result", ({ a, b, result }) => {
+    expectBoxEqualsApprox2(boxIntersection(_box(a), _box(b)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxIntersectsBox.spec.ts
+++ b/src/__test__/boxFunctions/boxIntersectsBox.spec.ts
@@ -1,45 +1,18 @@
 import { boxIntersectsBox } from "../../boxFunctions/boxIntersectsBox";
-import { boxReset } from "../../boxFunctions/boxReset";
 import { IntervalMode } from "../../const";
+import { _box } from "../helpers";
 
 describe("boxIntersectsBox", () => {
-  it("[-1 -1 +1 +1] ⋂? [-1 -1 +1 +1] => true", () => {
-    expect(boxIntersectsBox(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 1), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⋂? [-1 -1 +1 +2] => true", () => {
-    expect(boxIntersectsBox(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 2), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⋂? [0 0 0 0] => true", () => {
-    expect(boxIntersectsBox(boxReset(-1, -1, 1, 1), boxReset(0, 0, 0, 0), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⋂? [-0.5 -0.5 +0.5 +0.5] => true", () => {
-    expect(boxIntersectsBox(boxReset(-1, -1, 1, 1), boxReset(-0.5, -0.5, 0.5, 0.5), IntervalMode.CLOSED)).toBe(true);
-  });
-
-  it("[-1 -1 +1 +1] ⋂? [+3 -1 +5 +1] => false", () => {
-    expect(boxIntersectsBox(boxReset(-1, -1, 1, 1), boxReset(3, -1, 5, 1), IntervalMode.CLOSED)).toBe(false);
-  });
-
-  it("[-∞ -∞ +∞ +∞] ⋂? [-0.5 -0.5 +0.5 +0.5] => true", () => {
-    expect(
-      boxIntersectsBox(
-        boxReset(-Infinity, -Infinity, Infinity, Infinity),
-        boxReset(-0.5, -0.5, 0.5, 0.5),
-        IntervalMode.CLOSED,
-      ),
-    ).toBe(true);
-  });
-
-  it("[∞ ∞ -∞ -∞] ⋂? [-0.5 -0.5 +0.5 +0.5] => false", () => {
-    expect(
-      boxIntersectsBox(
-        boxReset(Infinity, Infinity, -Infinity, -Infinity),
-        boxReset(-0.5, -0.5, 0.5, 0.5),
-        IntervalMode.CLOSED,
-      ),
-    ).toBe(false);
+  it.each`
+    a                                             | b                         | imode                  | result
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 1]}         | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 2]}         | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[0, 0, 0, 0]}           | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[-0.5, -0.5, 0.5, 0.5]} | ${IntervalMode.CLOSED} | ${true}
+    ${[-1, -1, 1, 1]}                             | ${[3, -1, 5, 1]}          | ${IntervalMode.CLOSED} | ${false}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${IntervalMode.CLOSED} | ${true}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${IntervalMode.CLOSED} | ${false}
+  `("$a $b $imode => $result", ({ a, b, imode, result }) => {
+    expect(boxIntersectsBox(_box(a), _box(b), imode)).toBe(result);
   });
 });

--- a/src/__test__/boxFunctions/boxIsEmpty.spec.ts
+++ b/src/__test__/boxFunctions/boxIsEmpty.spec.ts
@@ -1,36 +1,18 @@
 import { boxIsEmpty } from "../../boxFunctions/boxIsEmpty";
-import { boxReset } from "../../boxFunctions/boxReset";
+import { _box } from "../helpers";
 
 describe("boxIsEmpty", () => {
-  it("[-1 -1 +1 +1] => false", () => {
-    expect(boxIsEmpty(boxReset(-1, -1, 1, 1))).toBe(false);
-  });
-
-  it("[+3 -1 +5 +1] => false", () => {
-    expect(boxIsEmpty(boxReset(3, -1, 5, 1))).toBe(false);
-  });
-
-  it("[0 0 0 0] => true", () => {
-    expect(boxIsEmpty(boxReset(0, 0, 0, 0))).toBe(true);
-  });
-
-  it("[-∞ -∞ +∞ +∞] => false", () => {
-    expect(boxIsEmpty(boxReset(-Infinity, -Infinity, Infinity, Infinity))).toBe(false);
-  });
-
-  it("[+∞ +∞ -∞ -∞] => true", () => {
-    expect(boxIsEmpty(boxReset(Infinity, Infinity, -Infinity, -Infinity))).toBe(true);
-  });
-
-  it("[0 0 -1 -1] => true", () => {
-    expect(boxIsEmpty(boxReset(0, 0, -1, -1))).toBe(true);
-  });
-
-  it("[Infinity Infinity 0 0] => true", () => {
-    expect(boxIsEmpty(boxReset(Infinity, Infinity, 0, 0))).toBe(true);
-  });
-
-  it("[NaN NaN NaN NaN] => true", () => {
-    expect(boxIsEmpty(boxReset(NaN, NaN, NaN, NaN))).toBe(true);
+  it.each`
+    box                                           | result
+    ${[-1, -1, 1, 1]}                             | ${false}
+    ${[3, -1, 5, 1]}                              | ${false}
+    ${[0, 0, 0, 0]}                               | ${true}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${false}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${true}
+    ${[0, 0, -1, -1]}                             | ${true}
+    ${[Infinity, Infinity, 0, 0]}                 | ${true}
+    ${[NaN, NaN, NaN, NaN]}                       | ${true}
+  `("$box => $result", ({ box, result }) => {
+    expect(boxIsEmpty(_box(box))).toBe(result);
   });
 });

--- a/src/__test__/boxFunctions/boxReset.spec.ts
+++ b/src/__test__/boxFunctions/boxReset.spec.ts
@@ -2,17 +2,17 @@ import { boxAlloc } from "../../boxFunctions/boxAlloc";
 import { boxReset } from "../../boxFunctions/boxReset";
 
 describe("boxReset", () => {
-  it("should copy components", () => {
-    const res = boxReset(4, 5, 6, 7);
-    expect(res.minX).toBe(4);
-    expect(res.minY).toBe(5);
-    expect(res.maxX).toBe(6);
-    expect(res.maxY).toBe(7);
+  it("sets components", () => {
+    expect(boxReset(4, 5, 6, 7)).toEqual({
+      minX: 4,
+      minY: 5,
+      maxX: 6,
+      maxY: 7,
+    });
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = boxAlloc();
-    const res = boxReset(4, 5, 6, 7, out);
-    expect(res).toBe(out);
+    expect(boxReset(4, 5, 6, 7, out)).toBe(out);
   });
 });

--- a/src/__test__/boxFunctions/boxTransformBy.spec.ts
+++ b/src/__test__/boxFunctions/boxTransformBy.spec.ts
@@ -1,5 +1,5 @@
 import { boxTransformBy } from "../../boxFunctions/boxTransformBy";
-import { expectBoxEqualsApprox2, _box, _mat2d } from "../helpers";
+import { expectBoxEqualsApprox, _box, _mat2d } from "../helpers";
 
 describe("boxTransformBy", () => {
   const SQRT2 = Math.SQRT2;
@@ -10,6 +10,6 @@ describe("boxTransformBy", () => {
     ${[4, 5, 6, 7]}   | ${[0, -1, 1, 0, -10, -20]}                                       | ${[-5, -26, -3, -24]}
     ${[-2, -2, 2, 2]} | ${[-0.5 * SQRT2, -0.5 * SQRT2, 0.5 * SQRT2, -0.5 * SQRT2, 0, 0]} | ${[-2 * SQRT2, -2 * SQRT2, 2 * SQRT2, 2 * SQRT2]}
   `("$box $mat => $result", ({ box, mat, result }) => {
-    expectBoxEqualsApprox2(boxTransformBy(_box(box), _mat2d(mat)), _box(result));
+    expectBoxEqualsApprox(boxTransformBy(_box(box), _mat2d(mat)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxTransformBy.spec.ts
+++ b/src/__test__/boxFunctions/boxTransformBy.spec.ts
@@ -1,37 +1,15 @@
-import { boxReset } from "../../boxFunctions/boxReset";
 import { boxTransformBy } from "../../boxFunctions/boxTransformBy";
-import { mat2dFromRotation } from "../../mat2dFunctions/mat2dFromRotation";
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectBoxEqualsApprox } from "../helpers";
+import { expectBoxEqualsApprox2, _box, _mat2d } from "../helpers";
 
 describe("boxTransformBy", () => {
-  it("[4 5 6 7], [1 0 0 1 0 0] => [4 5 6 7]", () => {
-    expectBoxEqualsApprox(boxTransformBy(boxReset(4, 5, 6, 7), mat2dIdentity()), 4, 5, 6, 7);
-  });
-
-  it("[4 5 6 7], [1 0 0 1 -10 -20] => [-6 -15 -4 -13]", () => {
-    expectBoxEqualsApprox(boxTransformBy(boxReset(4, 5, 6, 7), mat2dReset(1, 0, 0, 1, -10, -20)), -6, -15, -4, -13);
-  });
-
-  it("[4 5 6 7], [0 -1 1 0 -10 -20] => [-5 -26 -3 -24]", () => {
-    expectBoxEqualsApprox(
-      boxTransformBy(boxReset(4, 5, 6, 7), mat2dReset(0, -1, 1, 0, -10, -20)),
-      -5,
-      -26,
-      -3,
-      -24,
-    );
-  });
-
-  it("[-2 -2 2 2], [rot 135°] => [-2√2 -2√2 2√2 2√2]", () => {
-    const rot = mat2dFromRotation((3 * Math.PI) / 4);
-    expectBoxEqualsApprox(
-      boxTransformBy(boxReset(-2, -2, 2, 2), rot),
-      -2 * Math.SQRT2,
-      -2 * Math.SQRT2,
-      2 * Math.SQRT2,
-      2 * Math.SQRT2,
-    );
+  const SQRT2 = Math.SQRT2;
+  it.each`
+    box               | mat                                                              | result
+    ${[4, 5, 6, 7]}   | ${[1, 0, 0, 1, 0, 0]}                                            | ${[4, 5, 6, 7]}
+    ${[4, 5, 6, 7]}   | ${[1, 0, 0, 1, -10, -20]}                                        | ${[-6, -15, -4, -13]}
+    ${[4, 5, 6, 7]}   | ${[0, -1, 1, 0, -10, -20]}                                       | ${[-5, -26, -3, -24]}
+    ${[-2, -2, 2, 2]} | ${[-0.5 * SQRT2, -0.5 * SQRT2, 0.5 * SQRT2, -0.5 * SQRT2, 0, 0]} | ${[-2 * SQRT2, -2 * SQRT2, 2 * SQRT2, 2 * SQRT2]}
+  `("$box $mat => $result", ({ box, mat, result }) => {
+    expectBoxEqualsApprox2(boxTransformBy(_box(box), _mat2d(mat)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxUnion.spec.ts
+++ b/src/__test__/boxFunctions/boxUnion.spec.ts
@@ -1,45 +1,17 @@
-import { boxReset } from "../../boxFunctions/boxReset";
 import { boxUnion } from "../../boxFunctions/boxUnion";
-import { expectBoxEqualsApprox } from "../helpers";
+import { expectBoxEqualsApprox2, _box } from "../helpers";
 
 describe("boxUnion", () => {
-  it("[-1 -1 +1 +1] ∪ [-1 -1 +1 +1] => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxUnion(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 1)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1] ∪ [-1 -1 +1 +2] => [-1 -1 +1 +2]", () => {
-    expectBoxEqualsApprox(boxUnion(boxReset(-1, -1, 1, 1), boxReset(-1, -1, 1, 2)), -1, -1, 1, 2);
-  });
-
-  it("[-1 -1 +1 +1] ∪ [0 0 0 0] => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxUnion(boxReset(-1, -1, 1, 1), boxReset(0, 0, 0, 0)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1] ∪ [-0.5 -0.5 +0.5 +0.5] => [-1 -1 +1 +1]", () => {
-    expectBoxEqualsApprox(boxUnion(boxReset(-1, -1, 1, 1), boxReset(-0.5, -0.5, 0.5, 0.5)), -1, -1, 1, 1);
-  });
-
-  it("[-1 -1 +1 +1] ∪ [+3 -1 +5 +1] => [-1 -1 +5 +1]", () => {
-    expectBoxEqualsApprox(boxUnion(boxReset(-1, -1, 1, 1), boxReset(3, -1, 5, 1)), -1, -1, 5, 1);
-  });
-
-  it("[-∞ -∞ +∞ +∞] ∪ [-0.5 -0.5 +0.5 +0.5] => [-∞ -∞ +∞ +∞]", () => {
-    expectBoxEqualsApprox(
-      boxUnion(boxReset(-Infinity, -Infinity, Infinity, Infinity), boxReset(-0.5, -0.5, 0.5, 0.5)),
-      -Infinity,
-      -Infinity,
-      Infinity,
-      Infinity,
-    );
-  });
-
-  it("[+∞ +∞ -∞ -∞] ∪ [-0.5 -0.5 +0.5 +0.5] => [-0.5 -0.5 +0.5 +0.5]", () => {
-    expectBoxEqualsApprox(
-      boxUnion(boxReset(Infinity, Infinity, -Infinity, -Infinity), boxReset(-0.5, -0.5, 0.5, 0.5)),
-      -0.5,
-      -0.5,
-      0.5,
-      0.5,
-    );
+  it.each`
+    a                                             | b                         | result
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 1]}         | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]}                             | ${[-1, -1, 1, 2]}         | ${[-1, -1, 1, 2]}
+    ${[-1, -1, 1, 1]}                             | ${[0, 0, 0, 0]}           | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]}                             | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-1, -1, 1, 1]}
+    ${[-1, -1, 1, 1]}                             | ${[3, -1, 5, 1]}          | ${[-1, -1, 5, 1]}
+    ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-Infinity, -Infinity, Infinity, Infinity]}
+    ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-0.5, -0.5, 0.5, 0.5]}
+  `("$a $b => $result", ({ a, b, result }) => {
+    expectBoxEqualsApprox2(boxUnion(_box(a), _box(b)), _box(result));
   });
 });

--- a/src/__test__/boxFunctions/boxUnion.spec.ts
+++ b/src/__test__/boxFunctions/boxUnion.spec.ts
@@ -1,5 +1,5 @@
 import { boxUnion } from "../../boxFunctions/boxUnion";
-import { expectBoxEqualsApprox2, _box } from "../helpers";
+import { expectBoxEqualsApprox, _box } from "../helpers";
 
 describe("boxUnion", () => {
   it.each`
@@ -12,6 +12,6 @@ describe("boxUnion", () => {
     ${[-Infinity, -Infinity, Infinity, Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-Infinity, -Infinity, Infinity, Infinity]}
     ${[Infinity, Infinity, -Infinity, -Infinity]} | ${[-0.5, -0.5, 0.5, 0.5]} | ${[-0.5, -0.5, 0.5, 0.5]}
   `("$a $b => $result", ({ a, b, result }) => {
-    expectBoxEqualsApprox2(boxUnion(_box(a), _box(b)), _box(result));
+    expectBoxEqualsApprox(boxUnion(_box(a), _box(b)), _box(result));
   });
 });

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -22,6 +22,13 @@ export function expectBoxEqualsApprox(box: IBox, minX: number, minY: number, max
   expectEqualsApprox(box.maxY, maxY);
 }
 
+export function expectBoxEqualsApprox2(box: IBox, expected: IBox) {
+  expectEqualsApprox(box.minX, expected.minX);
+  expectEqualsApprox(box.minY, expected.minY);
+  expectEqualsApprox(box.maxX, expected.maxX);
+  expectEqualsApprox(box.maxY, expected.maxY);
+}
+
 export function expectVecEqualsApprox(actual: IVec, expected: IVec) {
   expectEqualsApprox(actual.x, expected.x);
   expectEqualsApprox(actual.y, expected.y);

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -1,3 +1,4 @@
+import { boxReset } from "../boxFunctions/boxReset";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { IBox, IMat2d, IPointIntersectionResult, IVec } from "../types";
 
@@ -52,5 +53,12 @@ export function expectMat2dEqualsApprox(actual: IMat2d, expected: IMat2d) {
 
 export function _mat2d(values: number[]) {
   expect(values).toHaveLength(6);
-  return mat2dReset(...(values as [number, number, number, number, number, number]));
+  const [a, b, c, d, e, f] = values;
+  return mat2dReset(a, b, c, d, e, f);
+}
+
+export function _box(values: number[]) {
+  expect(values).toHaveLength(4);
+  const [minX, minY, maxX, maxY] = values;
+  return boxReset(minX, minY, maxX, maxY);
 }

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -1,3 +1,4 @@
+import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { IBox, IMat2d, IPointIntersectionResult, IVec } from "../types";
 
 export const TEST_PRECISION_DIGITS = 10;
@@ -47,4 +48,9 @@ export function expectmat2dEqualsApprox(actual: IMat2d, expected: IMat2d) {
   expectEqualsApprox(actual.d, expected.d);
   expectEqualsApprox(actual.e, expected.e);
   expectEqualsApprox(actual.f, expected.f);
+}
+
+export function _mat2d(values: number[]) {
+  expect(values).toHaveLength(6);
+  return mat2dReset(...(values as [number, number, number, number, number, number]));
 }

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -41,7 +41,7 @@ export function expectIntersectionDNE(intersection: IPointIntersectionResult) {
   expect(intersection.t1).toBeNaN();
 }
 
-export function expectmat2dEqualsApprox(actual: IMat2d, expected: IMat2d) {
+export function expectMat2dEqualsApprox(actual: IMat2d, expected: IMat2d) {
   expectEqualsApprox(actual.a, expected.a);
   expectEqualsApprox(actual.b, expected.b);
   expectEqualsApprox(actual.c, expected.c);

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -1,6 +1,7 @@
 import { boxReset } from "../boxFunctions/boxReset";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { IBox, IMat2d, IPointIntersectionResult, IVec } from "../types";
+import { vecReset } from "../vecFunctions/vecReset";
 
 export const TEST_PRECISION_DIGITS = 10;
 
@@ -61,4 +62,10 @@ export function _box(values: number[]) {
   expect(values).toHaveLength(4);
   const [minX, minY, maxX, maxY] = values;
   return boxReset(minX, minY, maxX, maxY);
+}
+
+export function _vec(values: number[]) {
+  expect(values).toHaveLength(2);
+  const [x, y] = values;
+  return vecReset(x, y);
 }

--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -15,14 +15,7 @@ function expectEqualsApprox(actual: number, expected: number) {
   }
 }
 
-export function expectBoxEqualsApprox(box: IBox, minX: number, minY: number, maxX: number, maxY: number) {
-  expectEqualsApprox(box.minX, minX);
-  expectEqualsApprox(box.minY, minY);
-  expectEqualsApprox(box.maxX, maxX);
-  expectEqualsApprox(box.maxY, maxY);
-}
-
-export function expectBoxEqualsApprox2(box: IBox, expected: IBox) {
+export function expectBoxEqualsApprox(box: IBox, expected: IBox) {
   expectEqualsApprox(box.minX, expected.minX);
   expectEqualsApprox(box.minY, expected.minY);
   expectEqualsApprox(box.maxX, expected.maxX);

--- a/src/__test__/mat2dFunctions/mat2dAlloc.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dAlloc.spec.ts
@@ -1,9 +1,9 @@
 import { mat2dAlloc } from "../../mat2dFunctions/mat2dAlloc";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dAlloc", () => {
   it("returns [NaN, NaN, NaN, NaN, NaN, NaN]", () => {
-    expectmat2dEqualsApprox(mat2dAlloc(), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
+    expectMat2dEqualsApprox(mat2dAlloc(), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dClone.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dClone.spec.ts
@@ -1,11 +1,11 @@
 import { mat2dAlloc } from "../../mat2dFunctions/mat2dAlloc";
 import { mat2dClone } from "../../mat2dFunctions/mat2dClone";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dClone", () => {
   it("should copy components", () => {
-    expectmat2dEqualsApprox(mat2dClone(mat2dReset(3, 4, 5, 6, 7, 8)), mat2dReset(3, 4, 5, 6, 7, 8));
+    expectMat2dEqualsApprox(mat2dClone(mat2dReset(3, 4, 5, 6, 7, 8)), mat2dReset(3, 4, 5, 6, 7, 8));
   });
 
   it("should return a new mat2d if no `out`", () => {

--- a/src/__test__/mat2dFunctions/mat2dFromRotation.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dFromRotation.spec.ts
@@ -1,24 +1,24 @@
 import { mat2dFromRotation } from "../../mat2dFunctions/mat2dFromRotation";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dFromRotation", () => {
   it("0 => [1 0 0 1 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dFromRotation(0), mat2dReset(1, 0, 0, 1, 0, 0));
+    expectMat2dEqualsApprox(mat2dFromRotation(0), mat2dReset(1, 0, 0, 1, 0, 0));
   });
 
   it("π => [-1 0 0 -1 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dFromRotation(Math.PI), mat2dReset(-1, 0, 0, -1, 0, 0));
+    expectMat2dEqualsApprox(mat2dFromRotation(Math.PI), mat2dReset(-1, 0, 0, -1, 0, 0));
   });
 
   it("3π/4 => [-√2/2 -√2/2 +√2/2 -√2/2 0 0]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dFromRotation((3 * Math.PI) / 4),
       mat2dReset(-Math.SQRT1_2, -Math.SQRT1_2, Math.SQRT1_2, -Math.SQRT1_2, 0, 0),
     );
   });
 
   it("atan2(-8, -6) => [-0.6 0.8 -0.8 -0.6 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dFromRotation(Math.atan2(-8, -6)), mat2dReset(-0.6, 0.8, -0.8, -0.6, 0, 0));
+    expectMat2dEqualsApprox(mat2dFromRotation(Math.atan2(-8, -6)), mat2dReset(-0.6, 0.8, -0.8, -0.6, 0, 0));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dFromTranslation.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dFromTranslation.spec.ts
@@ -1,17 +1,17 @@
 import { mat2dFromTranslation } from "../../mat2dFunctions/mat2dFromTranslation";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dFromTranslation", () => {
   it("0, 0 => [1 0 0 1 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dFromTranslation(0, 0), mat2dReset(1, 0, 0, 1, 0, 0));
+    expectMat2dEqualsApprox(mat2dFromTranslation(0, 0), mat2dReset(1, 0, 0, 1, 0, 0));
   });
 
   it("10, -20 => [1 0 0 1 10 -20]", () => {
-    expectmat2dEqualsApprox(mat2dFromTranslation(10, -20), mat2dReset(1, 0, 0, 1, 10, -20));
+    expectMat2dEqualsApprox(mat2dFromTranslation(10, -20), mat2dReset(1, 0, 0, 1, 10, -20));
   });
 
   it("NaN, NaN => [1 0 0 1 NaN NaN]", () => {
-    expectmat2dEqualsApprox(mat2dFromTranslation(NaN, NaN), mat2dReset(1, 0, 0, 1, NaN, NaN));
+    expectMat2dEqualsApprox(mat2dFromTranslation(NaN, NaN), mat2dReset(1, 0, 0, 1, NaN, NaN));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dIdentity.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dIdentity.spec.ts
@@ -1,9 +1,9 @@
 import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dIdentity", () => {
   it("returns [1 0 0 1 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dIdentity(), mat2dReset(1, 0, 0, 1, 0, 0));
+    expectMat2dEqualsApprox(mat2dIdentity(), mat2dReset(1, 0, 0, 1, 0, 0));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
@@ -1,37 +1,17 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dInvert } from "../../mat2dFunctions/mat2dInvert";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectmat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dInvert", () => {
-  it("[1 0 0 1 0 0]⁻¹ => [1 0 0 1 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dIdentity()), mat2dReset(1, 0, 0, 1, 0, 0));
-  });
-
-  it("[1 0 0 1 -10 20]⁻¹ => [1 0 0 1 10 -20]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dReset(1, 0, 0, 1, -10, 20)), mat2dReset(1, 0, 0, 1, 10, -20));
-  });
-
-  it("[0.5 0 0 -0.25 0 0]⁻¹ => [2 0 0 -4 0 0]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dReset(0.5, 0, 0, -0.25, 0, 0)), mat2dReset(2, 0, 0, -4, 0, 0));
-  });
-
-  it("[0 0.5 -0.5 0 6 -8]⁻¹ => [0 -2 2 0 16 12]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dReset(0, 0.5, -0.5, 0, 6, -8)), mat2dReset(0, -2, 2, 0, 16, 12));
-  });
-
-  it("[4 4 4 4 6 8]⁻¹ => [NaN NaN NaN NaN NaN NaN]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dReset(4, 4, 4, 4, 6, 8)), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
-  });
-
-  it("[1 0 1 0 6 8]⁻¹ => [NaN NaN NaN NaN NaN NaN]", () => {
-    expectmat2dEqualsApprox(mat2dInvert(mat2dReset(1, 0, 1, 0, 6, 8)), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
-  });
-
-  it("[3 12 -4 -16 0 0]⁻¹ => [NaN NaN NaN NaN NaN NaN]", () => {
-    expectmat2dEqualsApprox(
-      mat2dInvert(mat2dReset(3, 12, -4, -16, 0, 0)),
-      mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN),
-    );
+  it.each`
+    input                       | output
+    ${[1, 0, 0, 1, 0, 0]}       | ${[1, 0, 0, 1, 0, 0]}
+    ${[1, 0, 0, 1, -10, 20]}    | ${[1, 0, 0, 1, 10, -20]}
+    ${[0.5, 0, 0, -0.25, 0, 0]} | ${[2, 0, 0, -4, 0, 0]}
+    ${[0, 0.5, -0.5, 0, 6, -8]} | ${[0, -2, 2, 0, 16, 12]}
+    ${[4, 4, 4, 4, 6, 8]}       | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
+    ${[1, 0, 1, 0, 6, 8]}       | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
+    ${[3, 12, -4, -16, 0, 0]}   | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
+  `("$input => $output", ({ input, output }) => {
+    expectmat2dEqualsApprox(mat2dInvert(_mat2d(input)), _mat2d(output));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
@@ -1,5 +1,5 @@
 import { mat2dInvert } from "../../mat2dFunctions/mat2dInvert";
-import { expectmat2dEqualsApprox, _mat2d } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dInvert", () => {
   it.each`
@@ -12,6 +12,6 @@ describe("mat2dInvert", () => {
     ${[1, 0, 1, 0, 6, 8]}       | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
     ${[3, 12, -4, -16, 0, 0]}   | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
   `("$input => $output", ({ input, output }) => {
-    expectmat2dEqualsApprox(mat2dInvert(_mat2d(input)), _mat2d(output));
+    expectMat2dEqualsApprox(mat2dInvert(_mat2d(input)), _mat2d(output));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dIsOrthogonal.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dIsOrthogonal.spec.ts
@@ -1,6 +1,5 @@
 import { mat2dIsOrthogonal } from "../../mat2dFunctions/mat2dIsOrthogonal";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { IMat2dValuesArray } from "../testTypes";
+import { _mat2d } from "../helpers";
 
 describe("mat2dIsOrthogonal", () => {
   it.each`
@@ -14,6 +13,6 @@ describe("mat2dIsOrthogonal", () => {
     ${[1, 0, 1, 0, 0, 0]}          | ${false}
     ${[NaN, NaN, NaN, NaN, 0, 0]}  | ${false}
   `("$mat => $result", ({ mat, result }) => {
-    expect(mat2dIsOrthogonal(mat2dReset(...(mat as IMat2dValuesArray)))).toBe(result);
+    expect(mat2dIsOrthogonal(_mat2d(mat))).toBe(result);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dIsOrthogonal.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dIsOrthogonal.spec.ts
@@ -1,37 +1,19 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dIsOrthogonal } from "../../mat2dFunctions/mat2dIsOrthogonal";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
+import { IMat2dValuesArray } from "../testTypes";
 
 describe("mat2dIsOrthogonal", () => {
-  it("[1 0 0 1 0 0] => true", () => {
-    expect(mat2dIsOrthogonal(mat2dIdentity())).toBe(true);
-  });
-
-  it("[1 0 0 1 6 -8] => true", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(1, 0, 0, 1, 6, -8))).toBe(true);
-  });
-
-  it("[1 0 0 -1 0 0] => true", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(1, 0, 0, -1, 0, 0))).toBe(true);
-  });
-
-  it("[0.6 -0.8 0.8 0.6 0 0] => true", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(0.6, -0.8, 0.8, 0.6, 0, 0))).toBe(true);
-  });
-
-  it("[2 0 0 2 0 0] => false", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(2, 0, 0, 2, 0, 0))).toBe(false);
-  });
-
-  it("[2 0 0 0.5 0 0] => false", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(2, 0, 0, 0.5, 0, 0))).toBe(false);
-  });
-
-  it("[1 0 1 0 0 0] => false", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(1, 0, 1, 0, 0, 0))).toBe(false);
-  });
-
-  it("[NaN NaN NaN NaN 0 0] => false", () => {
-    expect(mat2dIsOrthogonal(mat2dReset(NaN, NaN, NaN, NaN, 0, 0))).toBe(false);
+  it.each`
+    mat                            | result
+    ${[1, 0, 0, 1, 0, 0]}          | ${true}
+    ${[1, 0, 0, 1, 6, -8]}         | ${true}
+    ${[1, 0, 0, -1, 0, 0]}         | ${true}
+    ${[0.6, -0.8, 0.8, 0.6, 0, 0]} | ${true}
+    ${[2, 0, 0, 2, 0, 0]}          | ${false}
+    ${[2, 0, 0, 0.5, 0, 0]}        | ${false}
+    ${[1, 0, 1, 0, 0, 0]}          | ${false}
+    ${[NaN, NaN, NaN, NaN, 0, 0]}  | ${false}
+  `("$mat => $result", ({ mat, result }) => {
+    expect(mat2dIsOrthogonal(mat2dReset(...(mat as IMat2dValuesArray)))).toBe(result);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dMulMat2d.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dMulMat2d.spec.ts
@@ -1,31 +1,31 @@
 import { mat2dMulMat2d } from "../../mat2dFunctions/mat2dMulMat2d";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dMulMat2d", () => {
   it("[1 0 0 1 0 0][1 0 0 1 0 0] => [1 0 0 1 0 0]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dMulMat2d(mat2dReset(1, 0, 0, 1, 0, 0), mat2dReset(1, 0, 0, 1, 0, 0)),
       mat2dReset(1, 0, 0, 1, 0, 0),
     );
   });
 
   it("[3 4 5 6 7 8][1 0 0 1 0 0] => [3 4 5 6 7 8]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dMulMat2d(mat2dReset(3, 4, 5, 6, 7, 8), mat2dReset(1, 0, 0, 1, 0, 0)),
       mat2dReset(3, 4, 5, 6, 7, 8),
     );
   });
 
   it("[+1 -1 +1 +1 0 0][+1 +1 -1 +1 0 0] => [2 0 0 2 0 0]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dMulMat2d(mat2dReset(1, -1, 1, 1, 0, 0), mat2dReset(1, 1, -1, 1, 0, 0)),
       mat2dReset(2, 0, 0, 2, 0, 0),
     );
   });
 
   it("[3 4 5 6 7 8][1 -2 3 -4 5 -6] => [-7 -8 -11 -12 -8 -2]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dMulMat2d(mat2dReset(3, 4, 5, 6, 7, 8), mat2dReset(1, -2, 3, -4, 5, -6)),
       mat2dReset(-7, -8, -11, -12, -8, -2),
     );

--- a/src/__test__/mat2dFunctions/mat2dRotate.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dRotate.spec.ts
@@ -1,25 +1,25 @@
 import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dRotate } from "../../mat2dFunctions/mat2dRotate";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dRotate", () => {
   it("[1 0 0 1 0 0] rot π/3 => [1/2 -√3/2 √3/2 1/2 0 0]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dRotate(mat2dIdentity(), Math.PI / 3),
       mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 0, 0),
     );
   });
 
   it("[1 0 0 1 10 20] rot π/3 => [1/2 -√3/2 √3/2 1/2 10 20]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dRotate(mat2dReset(1, 0, 0, 1, 10, 20), Math.PI / 3),
       mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 10, 20),
     );
   });
 
   it("[1/2 -√3/2 √3/2 1/2 10 20] rot 2π/3 => [-1 0 0 -1 10 20]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dRotate(mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 10, 20), (2 * Math.PI) / 3),
       mat2dReset(-1, 0, 0, -1, 10, 20),
     );

--- a/src/__test__/mat2dFunctions/mat2dScale.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dScale.spec.ts
@@ -1,14 +1,14 @@
 import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dScale } from "../../mat2dFunctions/mat2dScale";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dScale", () => {
   it("[1 2 3 4 5 6] scale 7 => [7 14 21 28 35 42]", () => {
-    expectmat2dEqualsApprox(mat2dScale(mat2dReset(1, 2, 3, 4, 5, 6), 7), mat2dReset(7, 14, 21, 28, 35, 42));
+    expectMat2dEqualsApprox(mat2dScale(mat2dReset(1, 2, 3, 4, 5, 6), 7), mat2dReset(7, 14, 21, 28, 35, 42));
   });
 
   it("[1 0 0 1 0 0] scale NaN => [NaN NaN NaN NaN NaN NaN]", () => {
-    expectmat2dEqualsApprox(mat2dScale(mat2dIdentity(), NaN), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
+    expectMat2dEqualsApprox(mat2dScale(mat2dIdentity(), NaN), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dTranslate.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dTranslate.spec.ts
@@ -1,14 +1,14 @@
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dTranslate } from "../../mat2dFunctions/mat2dTranslate";
-import { expectmat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dTranslate", () => {
   it("[1 2 3 4 5 6], 7, 4 => [1 2 3 4 12 10]", () => {
-    expectmat2dEqualsApprox(mat2dTranslate(mat2dReset(1, 2, 3, 4, 5, 6), 7, 4), mat2dReset(1, 2, 3, 4, 12, 10));
+    expectMat2dEqualsApprox(mat2dTranslate(mat2dReset(1, 2, 3, 4, 5, 6), 7, 4), mat2dReset(1, 2, 3, 4, 12, 10));
   });
 
   it("[1 2 3 4 5 6] NaN, NaN => [1 2 3 4 NaN NaN]", () => {
-    expectmat2dEqualsApprox(
+    expectMat2dEqualsApprox(
       mat2dTranslate(mat2dReset(1, 2, 3, 4, 5, 6), NaN, NaN),
       mat2dReset(1, 2, 3, 4, NaN, NaN),
     );

--- a/src/__test__/testTypes.ts
+++ b/src/__test__/testTypes.ts
@@ -1,0 +1,1 @@
+export type IMat2dValuesArray = readonly [number, number, number, number, number, number];


### PR DESCRIPTION
Modernizes the code practices used in all the `box*` tests to follow latest Jest conventions