### PR TITLE
Modernize mat2d tests (use test.each, etc.)

### DIFF
--- a/src/__test__/mat2dFunctions/mat2dAlloc.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dAlloc.spec.ts
@@ -3,7 +3,7 @@ import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dAlloc", () => {
-  it("returns [NaN, NaN, NaN, NaN, NaN, NaN]", () => {
+  it("returns all NaNs", () => {
     expectMat2dEqualsApprox(mat2dAlloc(), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dClone.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dClone.spec.ts
@@ -4,19 +4,17 @@ import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { expectMat2dEqualsApprox } from "../helpers";
 
 describe("mat2dClone", () => {
-  it("should copy components", () => {
+  it("copies components", () => {
     expectMat2dEqualsApprox(mat2dClone(mat2dReset(3, 4, 5, 6, 7, 8)), mat2dReset(3, 4, 5, 6, 7, 8));
   });
 
-  it("should return a new mat2d if no `out`", () => {
+  it("returns a new mat2d if no `out`", () => {
     const mat = mat2dReset(3, 4, 5, 6, 7, 8);
-    const res = mat2dClone(mat);
-    expect(res).not.toBe(mat);
+    expect(mat2dClone(mat)).not.toBe(mat);
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = mat2dAlloc();
-    const res = mat2dClone(mat2dReset(3, 4, 5, 6, 7, 8), out);
-    expect(res).toBe(out);
+    expect(mat2dClone(mat2dReset(3, 4, 5, 6, 7, 8), out)).toBe(out);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dDeterminant.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dDeterminant.spec.ts
@@ -1,17 +1,13 @@
 import { mat2dDeterminant } from "../../mat2dFunctions/mat2dDeterminant";
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
+import { _mat2d } from "../helpers";
 
 describe("mat2dDeterminant", () => {
-  it("|1 0 0 1 0 0| => 1", () => {
-    expect(mat2dDeterminant(mat2dIdentity())).toBe(1);
-  });
-
-  it("|2 0 0 2 10 10| => 4", () => {
-    expect(mat2dDeterminant(mat2dReset(2, 0, 0, 2, 10, 10))).toBe(4);
-  });
-
-  it("|4 -7 8 5 NaN NaN| => 76", () => {
-    expect(mat2dDeterminant(mat2dReset(4, -7, 8, 5, NaN, NaN))).toBe(76);
+  it.each`
+    mat                        | result
+    ${[1, 0, 0, 1, 0, 0]}      | ${1}
+    ${[2, 0, 0, 2, 10, 10]}    | ${4}
+    ${[4, -7, 8, 5, NaN, NaN]} | ${76}
+  `("$mat => $result", ({ mat, result }) => {
+    expect(mat2dDeterminant(_mat2d(mat))).toBe(result);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dFromRotation.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dFromRotation.spec.ts
@@ -1,24 +1,16 @@
 import { mat2dFromRotation } from "../../mat2dFunctions/mat2dFromRotation";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
+const SQRT1_2 = Math.SQRT1_2;
+const PI = Math.PI;
 describe("mat2dFromRotation", () => {
-  it("0 => [1 0 0 1 0 0]", () => {
-    expectMat2dEqualsApprox(mat2dFromRotation(0), mat2dReset(1, 0, 0, 1, 0, 0));
-  });
-
-  it("π => [-1 0 0 -1 0 0]", () => {
-    expectMat2dEqualsApprox(mat2dFromRotation(Math.PI), mat2dReset(-1, 0, 0, -1, 0, 0));
-  });
-
-  it("3π/4 => [-√2/2 -√2/2 +√2/2 -√2/2 0 0]", () => {
-    expectMat2dEqualsApprox(
-      mat2dFromRotation((3 * Math.PI) / 4),
-      mat2dReset(-Math.SQRT1_2, -Math.SQRT1_2, Math.SQRT1_2, -Math.SQRT1_2, 0, 0),
-    );
-  });
-
-  it("atan2(-8, -6) => [-0.6 0.8 -0.8 -0.6 0 0]", () => {
-    expectMat2dEqualsApprox(mat2dFromRotation(Math.atan2(-8, -6)), mat2dReset(-0.6, 0.8, -0.8, -0.6, 0, 0));
+  it.each`
+    rot                   | result
+    ${0}                  | ${[1, 0, 0, 1, 0, 0]}
+    ${PI}                 | ${[-1, 0, 0, -1, 0, 0]}
+    ${(3 * PI) / 4}       | ${[-SQRT1_2, -SQRT1_2, SQRT1_2, -SQRT1_2, 0, 0]}
+    ${Math.atan2(-8, -6)} | ${[-0.6, 0.8, -0.8, -0.6, 0, 0]}
+  `("$rot => $result", ({ rot, result }) => {
+    expectMat2dEqualsApprox(mat2dFromRotation(rot), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dFromTranslation.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dFromTranslation.spec.ts
@@ -1,17 +1,13 @@
 import { mat2dFromTranslation } from "../../mat2dFunctions/mat2dFromTranslation";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dFromTranslation", () => {
-  it("0, 0 => [1 0 0 1 0 0]", () => {
-    expectMat2dEqualsApprox(mat2dFromTranslation(0, 0), mat2dReset(1, 0, 0, 1, 0, 0));
-  });
-
-  it("10, -20 => [1 0 0 1 10 -20]", () => {
-    expectMat2dEqualsApprox(mat2dFromTranslation(10, -20), mat2dReset(1, 0, 0, 1, 10, -20));
-  });
-
-  it("NaN, NaN => [1 0 0 1 NaN NaN]", () => {
-    expectMat2dEqualsApprox(mat2dFromTranslation(NaN, NaN), mat2dReset(1, 0, 0, 1, NaN, NaN));
+  it.each`
+    x      | y      | result
+    ${0}   | ${0}   | ${[1, 0, 0, 1, 0, 0]}
+    ${10}  | ${-20} | ${[1, 0, 0, 1, 10, -20]}
+    ${NaN} | ${NaN} | ${[1, 0, 0, 1, NaN, NaN]}
+  `("$x $y => $result", ({ x, y, result }) => {
+    expectMat2dEqualsApprox(mat2dFromTranslation(x, y), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dInvert.spec.ts
@@ -3,7 +3,7 @@ import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dInvert", () => {
   it.each`
-    input                       | output
+    mat                         | result
     ${[1, 0, 0, 1, 0, 0]}       | ${[1, 0, 0, 1, 0, 0]}
     ${[1, 0, 0, 1, -10, 20]}    | ${[1, 0, 0, 1, 10, -20]}
     ${[0.5, 0, 0, -0.25, 0, 0]} | ${[2, 0, 0, -4, 0, 0]}
@@ -11,7 +11,7 @@ describe("mat2dInvert", () => {
     ${[4, 4, 4, 4, 6, 8]}       | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
     ${[1, 0, 1, 0, 6, 8]}       | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
     ${[3, 12, -4, -16, 0, 0]}   | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
-  `("$input => $output", ({ input, output }) => {
-    expectMat2dEqualsApprox(mat2dInvert(_mat2d(input)), _mat2d(output));
+  `("$mat => $result", ({ mat, result }) => {
+    expectMat2dEqualsApprox(mat2dInvert(_mat2d(mat)), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dIsTranslationOnly.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dIsTranslationOnly.spec.ts
@@ -1,41 +1,19 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
 import { mat2dIsTranslationOnly } from "../../mat2dFunctions/mat2dIsTranslationOnly";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
+import { _mat2d } from "../helpers";
 
 describe("mat2dIsTranslationOnly", () => {
-  it("[1 0 0 1 0 0] => true", () => {
-    expect(mat2dIsTranslationOnly(mat2dIdentity())).toBe(true);
-  });
-
-  it("[1 0 0 1 6 -8] => true", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(1, 0, 0, 1, 6, -8))).toBe(true);
-  });
-
-  it("[1 0 0 -1 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(1, 0, 0, -1, 0, 0))).toBe(false);
-  });
-
-  it("[0.6 -0.8 0.8 0.6 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(0.6, -0.8, 0.8, 0.6, 0, 0))).toBe(false);
-  });
-
-  it("[2 0 0 2 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(2, 0, 0, 2, 0, 0))).toBe(false);
-  });
-
-  it("[2 0 0 0.5 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(2, 0, 0, 0.5, 0, 0))).toBe(false);
-  });
-
-  it("[1 0 1 0 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(1, 0, 1, 0, 0, 0))).toBe(false);
-  });
-
-  it("[NaN NaN NaN NaN 0 0] => false", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(NaN, NaN, NaN, NaN, 0, 0))).toBe(false);
-  });
-
-  it("[1 0 0 1 NaN NaN] => true", () => {
-    expect(mat2dIsTranslationOnly(mat2dReset(1, 0, 0, 1, NaN, NaN))).toBe(true);
+  it.each`
+    mat                            | result
+    ${[1, 0, 0, 1, 0, 0]}          | ${true}
+    ${[1, 0, 0, 1, 6, -8]}         | ${true}
+    ${[1, 0, 0, -1, 0, 0]}         | ${false}
+    ${[0.6, -0.8, 0.8, 0.6, 0, 0]} | ${false}
+    ${[2, 0, 0, 2, 0, 0]}          | ${false}
+    ${[2, 0, 0, 0.5, 0, 0]}        | ${false}
+    ${[1, 0, 1, 0, 0, 0]}          | ${false}
+    ${[NaN, NaN, NaN, NaN, 0, 0]}  | ${false}
+    ${[1, 0, 0, 1, NaN, NaN]}      | ${true}
+  `("$mat => $result", ({ mat, result }) => {
+    expect(mat2dIsTranslationOnly(_mat2d(mat))).toBe(result);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dMulMat2d.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dMulMat2d.spec.ts
@@ -1,33 +1,14 @@
 import { mat2dMulMat2d } from "../../mat2dFunctions/mat2dMulMat2d";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dMulMat2d", () => {
-  it("[1 0 0 1 0 0][1 0 0 1 0 0] => [1 0 0 1 0 0]", () => {
-    expectMat2dEqualsApprox(
-      mat2dMulMat2d(mat2dReset(1, 0, 0, 1, 0, 0), mat2dReset(1, 0, 0, 1, 0, 0)),
-      mat2dReset(1, 0, 0, 1, 0, 0),
-    );
-  });
-
-  it("[3 4 5 6 7 8][1 0 0 1 0 0] => [3 4 5 6 7 8]", () => {
-    expectMat2dEqualsApprox(
-      mat2dMulMat2d(mat2dReset(3, 4, 5, 6, 7, 8), mat2dReset(1, 0, 0, 1, 0, 0)),
-      mat2dReset(3, 4, 5, 6, 7, 8),
-    );
-  });
-
-  it("[+1 -1 +1 +1 0 0][+1 +1 -1 +1 0 0] => [2 0 0 2 0 0]", () => {
-    expectMat2dEqualsApprox(
-      mat2dMulMat2d(mat2dReset(1, -1, 1, 1, 0, 0), mat2dReset(1, 1, -1, 1, 0, 0)),
-      mat2dReset(2, 0, 0, 2, 0, 0),
-    );
-  });
-
-  it("[3 4 5 6 7 8][1 -2 3 -4 5 -6] => [-7 -8 -11 -12 -8 -2]", () => {
-    expectMat2dEqualsApprox(
-      mat2dMulMat2d(mat2dReset(3, 4, 5, 6, 7, 8), mat2dReset(1, -2, 3, -4, 5, -6)),
-      mat2dReset(-7, -8, -11, -12, -8, -2),
-    );
+  it.each`
+    a                      | b                        | result
+    ${[1, 0, 0, 1, 0, 0]}  | ${[1, 0, 0, 1, 0, 0]}    | ${[1, 0, 0, 1, 0, 0]}
+    ${[3, 4, 5, 6, 7, 8]}  | ${[1, 0, 0, 1, 0, 0]}    | ${[3, 4, 5, 6, 7, 8]}
+    ${[1, -1, 1, 1, 0, 0]} | ${[1, 1, -1, 1, 0, 0]}   | ${[2, 0, 0, 2, 0, 0]}
+    ${[3, 4, 5, 6, 7, 8]}  | ${[1, -2, 3, -4, 5, -6]} | ${[-7, -8, -11, -12, -8, -2]}
+  `("$a $b => $result", ({ a, b, result }) => {
+    expectMat2dEqualsApprox(mat2dMulMat2d(_mat2d(a), _mat2d(b)), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dReset.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dReset.spec.ts
@@ -2,19 +2,19 @@ import { mat2dAlloc } from "../../mat2dFunctions/mat2dAlloc";
 import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 
 describe("mat2dReset", () => {
-  it("should copy components", () => {
-    const res = mat2dReset(3, 4, 5, 6, 7, 8);
-    expect(res.a).toBe(3);
-    expect(res.b).toBe(4);
-    expect(res.c).toBe(5);
-    expect(res.d).toBe(6);
-    expect(res.e).toBe(7);
-    expect(res.f).toBe(8);
+  it("copies components", () => {
+    expect(mat2dReset(3, 4, 5, 6, 7, 8)).toEqual({
+      a: 3,
+      b: 4,
+      c: 5,
+      d: 6,
+      e: 7,
+      f: 8,
+    });
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = mat2dAlloc();
-    const res = mat2dReset(3, 4, 5, 6, 7, 8, out);
-    expect(res).toBe(out);
+    expect(mat2dReset(3, 4, 5, 6, 7, 8, out)).toBe(out);
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dRotate.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dRotate.spec.ts
@@ -1,27 +1,16 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dRotate } from "../../mat2dFunctions/mat2dRotate";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
+
+const PI = Math.PI;
+const SQRT3 = Math.sqrt(3);
 
 describe("mat2dRotate", () => {
-  it("[1 0 0 1 0 0] rot π/3 => [1/2 -√3/2 √3/2 1/2 0 0]", () => {
-    expectMat2dEqualsApprox(
-      mat2dRotate(mat2dIdentity(), Math.PI / 3),
-      mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 0, 0),
-    );
-  });
-
-  it("[1 0 0 1 10 20] rot π/3 => [1/2 -√3/2 √3/2 1/2 10 20]", () => {
-    expectMat2dEqualsApprox(
-      mat2dRotate(mat2dReset(1, 0, 0, 1, 10, 20), Math.PI / 3),
-      mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 10, 20),
-    );
-  });
-
-  it("[1/2 -√3/2 √3/2 1/2 10 20] rot 2π/3 => [-1 0 0 -1 10 20]", () => {
-    expectMat2dEqualsApprox(
-      mat2dRotate(mat2dReset(0.5, -0.5 * Math.sqrt(3), 0.5 * Math.sqrt(3), 0.5, 10, 20), (2 * Math.PI) / 3),
-      mat2dReset(-1, 0, 0, -1, 10, 20),
-    );
+  it.each`
+    mat                                              | rot             | result
+    ${[1, 0, 0, 1, 0, 0]}                            | ${PI / 3}       | ${[0.5, -0.5 * SQRT3, 0.5 * SQRT3, 0.5, 0, 0]}
+    ${[1, 0, 0, 1, 10, 20]}                          | ${PI / 3}       | ${[0.5, -0.5 * SQRT3, 0.5 * SQRT3, 0.5, 10, 20]}
+    ${[0.5, -0.5 * SQRT3, 0.5 * SQRT3, 0.5, 10, 20]} | ${(2 * PI) / 3} | ${[-1, 0, 0, -1, 10, 20]}
+  `("$mat $rot => $result", ({ mat, rot, result }) => {
+    expectMat2dEqualsApprox(mat2dRotate(_mat2d(mat), rot), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dScale.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dScale.spec.ts
@@ -1,14 +1,12 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dScale } from "../../mat2dFunctions/mat2dScale";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dScale", () => {
-  it("[1 2 3 4 5 6] scale 7 => [7 14 21 28 35 42]", () => {
-    expectMat2dEqualsApprox(mat2dScale(mat2dReset(1, 2, 3, 4, 5, 6), 7), mat2dReset(7, 14, 21, 28, 35, 42));
-  });
-
-  it("[1 0 0 1 0 0] scale NaN => [NaN NaN NaN NaN NaN NaN]", () => {
-    expectMat2dEqualsApprox(mat2dScale(mat2dIdentity(), NaN), mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN));
+  it.each`
+    mat                   | s      | result
+    ${[1, 2, 3, 4, 5, 6]} | ${7}   | ${[7, 14, 21, 28, 35, 42]}
+    ${[1, 0, 0, 1, 0, 0]} | ${NaN} | ${[NaN, NaN, NaN, NaN, NaN, NaN]}
+  `("$mat $s => $result", ({ mat, s, result }) => {
+    expectMat2dEqualsApprox(mat2dScale(_mat2d(mat), s), _mat2d(result));
   });
 });

--- a/src/__test__/mat2dFunctions/mat2dTranslate.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dTranslate.spec.ts
@@ -1,16 +1,12 @@
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
 import { mat2dTranslate } from "../../mat2dFunctions/mat2dTranslate";
-import { expectMat2dEqualsApprox } from "../helpers";
+import { expectMat2dEqualsApprox, _mat2d } from "../helpers";
 
 describe("mat2dTranslate", () => {
-  it("[1 2 3 4 5 6], 7, 4 => [1 2 3 4 12 10]", () => {
-    expectMat2dEqualsApprox(mat2dTranslate(mat2dReset(1, 2, 3, 4, 5, 6), 7, 4), mat2dReset(1, 2, 3, 4, 12, 10));
-  });
-
-  it("[1 2 3 4 5 6] NaN, NaN => [1 2 3 4 NaN NaN]", () => {
-    expectMat2dEqualsApprox(
-      mat2dTranslate(mat2dReset(1, 2, 3, 4, 5, 6), NaN, NaN),
-      mat2dReset(1, 2, 3, 4, NaN, NaN),
-    );
+  it.each`
+    mat                   | x      | y      | result
+    ${[1, 2, 3, 4, 5, 6]} | ${7}   | ${4}   | ${[1, 2, 3, 4, 12, 10]}
+    ${[1, 2, 3, 4, 5, 6]} | ${NaN} | ${NaN} | ${[1, 2, 3, 4, NaN, NaN]}
+  `("$mat $x $y => $result", ({ mat, x, y, result }) => {
+    expectMat2dEqualsApprox(mat2dTranslate(_mat2d(mat), x, y), _mat2d(result));
   });
 });


### PR DESCRIPTION
Modernizes the code practices used in all the `mat2d*` tests to follow latest Jest conventions.

Follow up to #28 