### PR TITLE
Modernize vec tests (use test.each, etc.)

### DIFF
--- a/src/__test__/vecFunctions/vecAdd.spec.ts
+++ b/src/__test__/vecFunctions/vecAdd.spec.ts
@@ -1,9 +1,11 @@
 import { vecAdd } from "../../vecFunctions/vecAdd";
-import { vecReset } from "../../vecFunctions/vecReset";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecAdd", () => {
-  it("(4,5) + (20,30) => (24,35)", () => {
-    expectVecEqualsApprox(vecAdd(vecReset(4, 5), vecReset(20, 30)), vecReset(24, 35));
+  it.each`
+    v0        | v1          | result
+    ${[4, 5]} | ${[20, 30]} | ${[24, 35]}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expectVecEqualsApprox(vecAdd(_vec(v0), _vec(v1)), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecClone.spec.ts
+++ b/src/__test__/vecFunctions/vecClone.spec.ts
@@ -4,19 +4,17 @@ import { vecReset } from "../../vecFunctions/vecReset";
 import { expectVecEqualsApprox } from "../helpers";
 
 describe("vecClone", () => {
-  it("should copy components", () => {
+  it("copies components", () => {
     expectVecEqualsApprox(vecClone(vecReset(4, 5)), vecReset(4, 5));
   });
 
-  it("should return a new vector if no `out`", () => {
+  it("returns a new vector if no `out`", () => {
     const vec = vecReset(4, 5);
-    const res = vecClone(vec);
-    expect(res).not.toBe(vec);
+    expect(vecClone(vec)).not.toBe(vec);
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = vecAlloc();
-    const res = vecClone(vecReset(4, 5), out);
-    expect(res).toBe(out);
+    expect(vecClone(vecReset(4, 5), out)).toBe(out);
   });
 });

--- a/src/__test__/vecFunctions/vecDistance.spec.ts
+++ b/src/__test__/vecFunctions/vecDistance.spec.ts
@@ -1,16 +1,13 @@
 import { vecDistance } from "../../vecFunctions/vecDistance";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecDistance", () => {
-  it("(2,4), (2,4) => 0", () => {
-    expect(vecDistance(vecReset(2, 4), vecReset(2, 4))).toBe(0);
-  });
-
-  it("(0,4), (0,-5) => 9", () => {
-    expect(vecDistance(vecReset(0, 4), vecReset(0, -5))).toBe(9);
-  });
-
-  it("(10,10), (16,18) => 10", () => {
-    expect(vecDistance(vecReset(10, 10), vecReset(16, 18))).toBe(10);
+  it.each`
+    v0          | v1          | result
+    ${[2, 4]}   | ${[2, 4]}   | ${0}
+    ${[0, 4]}   | ${[0, -5]}  | ${9}
+    ${[10, 10]} | ${[16, 18]} | ${10}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expect(vecDistance(_vec(v0), _vec(v1))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecDistanceSq.spec.ts
+++ b/src/__test__/vecFunctions/vecDistanceSq.spec.ts
@@ -1,16 +1,13 @@
 import { vecDistanceSq } from "../../vecFunctions/vecDistanceSq";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecDistanceSq", () => {
-  it("(2,4), (2,4) => 0", () => {
-    expect(vecDistanceSq(vecReset(2, 4), vecReset(2, 4))).toBe(0);
-  });
-
-  it("(0,4), (0,-5) => 81", () => {
-    expect(vecDistanceSq(vecReset(0, 4), vecReset(0, -5))).toBe(81);
-  });
-
-  it("(10,10), (16,18) => 100", () => {
-    expect(vecDistanceSq(vecReset(10, 10), vecReset(16, 18))).toBe(100);
+  it.each`
+    v0          | v1          | result
+    ${[2, 4]}   | ${[2, 4]}   | ${0}
+    ${[0, 4]}   | ${[0, -5]}  | ${81}
+    ${[10, 10]} | ${[16, 18]} | ${100}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expect(vecDistanceSq(_vec(v0), _vec(v1))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecDot.spec.ts
+++ b/src/__test__/vecFunctions/vecDot.spec.ts
@@ -1,8 +1,11 @@
 import { vecDot } from "../../vecFunctions/vecDot";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecDot", () => {
-  it("(2,4) • (3,10) => 46", () => {
-    expect(vecDot(vecReset(2, 4), vecReset(3, 10))).toBe(46);
+  it.each`
+    v0        | v1         | result
+    ${[2, 4]} | ${[3, 10]} | ${46}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expect(vecDot(_vec(v0), _vec(v1))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecGetLength.spec.ts
+++ b/src/__test__/vecFunctions/vecGetLength.spec.ts
@@ -1,16 +1,13 @@
 import { vecGetLength } from "../../vecFunctions/vecGetLength";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecGetLength", () => {
-  it("(0,0) => 0", () => {
-    expect(vecGetLength(vecReset(0, 0))).toBe(0);
-  });
-
-  it("(0,-4) => 4", () => {
-    expect(vecGetLength(vecReset(0, -4))).toBe(4);
-  });
-
-  it("(12,16) => 20", () => {
-    expect(vecGetLength(vecReset(12, 16))).toBe(20);
+  it.each`
+    vec         | result
+    ${[0, 0]}   | ${0}
+    ${[0, -4]}  | ${4}
+    ${[12, 16]} | ${20}
+  `("$vec => $result", ({ vec, result }) => {
+    expect(vecGetLength(_vec(vec))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecGetLengthSq.spec.ts
+++ b/src/__test__/vecFunctions/vecGetLengthSq.spec.ts
@@ -1,16 +1,13 @@
 import { vecGetLengthSq } from "../../vecFunctions/vecGetLengthSq";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecGetLengthSq", () => {
-  it("(0,0) => 0", () => {
-    expect(vecGetLengthSq(vecReset(0, 0))).toBe(0);
-  });
-
-  it("(0,-4) => 16", () => {
-    expect(vecGetLengthSq(vecReset(0, -4))).toBe(16);
-  });
-
-  it("(12,16) => 400", () => {
-    expect(vecGetLengthSq(vecReset(12, 16))).toBe(400);
+  it.each`
+    vec         | result
+    ${[0, 0]}   | ${0}
+    ${[0, -4]}  | ${16}
+    ${[12, 16]} | ${400}
+  `("$vec => $result", ({ vec, result }) => {
+    expect(vecGetLengthSq(_vec(vec))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecGetManhattanLength.spec.ts
+++ b/src/__test__/vecFunctions/vecGetManhattanLength.spec.ts
@@ -1,16 +1,13 @@
 import { vecGetManhattanLength } from "../../vecFunctions/vecGetManhattanLength";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecGetManhattanLength", () => {
-  it("(0,0) => 0", () => {
-    expect(vecGetManhattanLength(vecReset(0, 0))).toBe(0);
-  });
-
-  it("(0,-4) => 4", () => {
-    expect(vecGetManhattanLength(vecReset(0, -4))).toBe(4);
-  });
-
-  it("(-12,16) => 28", () => {
-    expect(vecGetManhattanLength(vecReset(-12, 16))).toBe(28);
+  it.each`
+    vec         | result
+    ${[0, 0]}   | ${0}
+    ${[0, -4]}  | ${4}
+    ${[12, 16]} | ${28}
+  `("$vec => $result", ({ vec, result }) => {
+    expect(vecGetManhattanLength(_vec(vec))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecLerp.spec.ts
+++ b/src/__test__/vecFunctions/vecLerp.spec.ts
@@ -1,37 +1,18 @@
 import { vecLerp } from "../../vecFunctions/vecLerp";
-import { vecReset } from "../../vecFunctions/vecReset";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecLerp", () => {
-  it("(0,0), (1,0), 0 => (0,0)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(0, 0), vecReset(1, 0), 0), vecReset(0, 0));
-  });
-
-  it("(0,0), (1,0), 0.5 => (0.5,0)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(0, 0), vecReset(1, 0), 0.5), vecReset(0.5, 0));
-  });
-
-  it("(0,0), (1,0), 1 => (1,0)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(0, 0), vecReset(1, 0), 1), vecReset(1, 0));
-  });
-
-  it("(4,4), (4,4), 0 => (4,4)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(4, 4), vecReset(4, 4), 0), vecReset(4, 4));
-  });
-
-  it("(4,4), (4,4), 2 => (4,4)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(4, 4), vecReset(4, 4), 2), vecReset(4, 4));
-  });
-
-  it("(10,10), (20,30), 0.75 => (17.5,25)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(10, 10), vecReset(20, 30), 0.75), vecReset(17.5, 25));
-  });
-
-  it("(0,0), (1,1), NaN => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(0, 0), vecReset(1, 1), NaN), vecReset(NaN, NaN));
-  });
-
-  it("(0,0), (0,0), NaN => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecLerp(vecReset(0, 0), vecReset(0, 0), NaN), vecReset(NaN, NaN));
+  it.each`
+    v0          | v1          | scalar  | result
+    ${[0, 0]}   | ${[1, 0]}   | ${0}    | ${[0, 0]}
+    ${[0, 0]}   | ${[1, 0]}   | ${0.5}  | ${[0.5, 0]}
+    ${[0, 0]}   | ${[1, 0]}   | ${1}    | ${[1, 0]}
+    ${[4, 4]}   | ${[4, 4]}   | ${0}    | ${[4, 4]}
+    ${[4, 4]}   | ${[4, 4]}   | ${2}    | ${[4, 4]}
+    ${[10, 10]} | ${[20, 30]} | ${0.75} | ${[17.5, 25]}
+    ${[0, 0]}   | ${[1, 1]}   | ${NaN}  | ${[NaN, NaN]}
+    ${[0, 0]}   | ${[0, 0]}   | ${NaN}  | ${[NaN, NaN]}
+  `("$v0 $v1 $scalar => $result", ({ v0, v1, scalar, result }) => {
+    expectVecEqualsApprox(vecLerp(_vec(v0), _vec(v1), scalar), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecManhattanDistance.spec.ts
+++ b/src/__test__/vecFunctions/vecManhattanDistance.spec.ts
@@ -1,16 +1,13 @@
 import { vecManhattanDistance } from "../../vecFunctions/vecManhattanDistance";
-import { vecReset } from "../../vecFunctions/vecReset";
+import { _vec } from "../helpers";
 
 describe("vecManhattanDistance", () => {
-  it("(4,6), (4,6) => 0", () => {
-    expect(vecManhattanDistance(vecReset(4, 6), vecReset(4, 6))).toBe(0);
-  });
-
-  it("(0,-4), (0,6) => 10", () => {
-    expect(vecManhattanDistance(vecReset(0, -4), vecReset(0, 6))).toBe(10);
-  });
-
-  it("(-4,6), (6,20) => 24", () => {
-    expect(vecManhattanDistance(vecReset(-4, 6), vecReset(6, 20))).toBe(24);
+  it.each`
+    v0         | v1         | result
+    ${[4, 6]}  | ${[4, 6]}  | ${0}
+    ${[0, -4]} | ${[0, 6]}  | ${10}
+    ${[-4, 6]} | ${[6, 20]} | ${24}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expect(vecManhattanDistance(_vec(v0), _vec(v1))).toBe(result);
   });
 });

--- a/src/__test__/vecFunctions/vecNormalize.spec.ts
+++ b/src/__test__/vecFunctions/vecNormalize.spec.ts
@@ -1,25 +1,15 @@
 import { vecNormalize } from "../../vecFunctions/vecNormalize";
-import { vecReset } from "../../vecFunctions/vecReset";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecNormalize", () => {
-  it("(0.6,-0.8) => (0.6,-0.8)", () => {
-    expectVecEqualsApprox(vecNormalize(vecReset(0.6, -0.8)), vecReset(0.6, -0.8));
-  });
-
-  it("(0.3,-0.4) => (0.6,-0.8)", () => {
-    expectVecEqualsApprox(vecNormalize(vecReset(0.3, -0.4)), vecReset(0.6, -0.8));
-  });
-
-  it("(-20,21) => (-20/29,21/29)", () => {
-    expectVecEqualsApprox(vecNormalize(vecReset(-20, 21)), vecReset(-20 / 29, 21 / 29));
-  });
-
-  it("(0,0) => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecNormalize(vecReset(0, 0)), vecReset(NaN, NaN));
-  });
-
-  it("(NaN,NaN) => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecNormalize(vecReset(NaN, NaN)), vecReset(NaN, NaN));
+  it.each`
+    vec            | result
+    ${[0.6, -0.8]} | ${[0.6, -0.8]}
+    ${[0.3, -0.4]} | ${[0.6, -0.8]}
+    ${[-20, 21]}   | ${[-20 / 29, 21 / 29]}
+    ${[0, 0]}      | ${[NaN, NaN]}
+    ${[NaN, NaN]}  | ${[NaN, NaN]}
+  `("$vec => $result", ({ vec, result }) => {
+    expectVecEqualsApprox(vecNormalize(_vec(vec)), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecPerp.spec.ts
+++ b/src/__test__/vecFunctions/vecPerp.spec.ts
@@ -1,21 +1,14 @@
 import { vecPerp } from "../../vecFunctions/vecPerp";
-import { vecReset } from "../../vecFunctions/vecReset";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecPerp", () => {
-  it("⟂(4,5) => (-5,4)", () => {
-    expectVecEqualsApprox(vecPerp(vecReset(4, 5)), vecReset(-5, 4));
-  });
-
-  it("⟂(-2,-3) => (3,-2)", () => {
-    expectVecEqualsApprox(vecPerp(vecReset(-2, -3)), vecReset(3, -2));
-  });
-
-  it("⟂(0,0) => (0,0)", () => {
-    expectVecEqualsApprox(vecPerp(vecReset(0, 0)), vecReset(0, 0));
-  });
-
-  it("⟂(NaN,NaN) => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecPerp(vecReset(NaN, NaN)), vecReset(NaN, NaN));
+  it.each`
+    vec           | result
+    ${[4, 5]}     | ${[-5, 4]}
+    ${[-2, -3]}   | ${[3, -2]}
+    ${[0, 0]}     | ${[0, 0]}
+    ${[NaN, NaN]} | ${[NaN, NaN]}
+  `("$vec => $result", ({ vec, result }) => {
+    expectVecEqualsApprox(vecPerp(_vec(vec)), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecReset.spec.ts
+++ b/src/__test__/vecFunctions/vecReset.spec.ts
@@ -2,15 +2,15 @@ import { vecAlloc } from "../../vecFunctions/vecAlloc";
 import { vecReset } from "../../vecFunctions/vecReset";
 
 describe("vecReset", () => {
-  it("should copy components", () => {
-    const res = vecReset(4, 5);
-    expect(res.x).toBe(4);
-    expect(res.y).toBe(5);
+  it("copies components", () => {
+    expect(vecReset(4, 5)).toEqual({
+      x: 4,
+      y: 5,
+    });
   });
 
-  it("should return `out` if given", () => {
+  it("returns `out` if given", () => {
     const out = vecAlloc();
-    const res = vecReset(4, 5, out);
-    expect(res).toBe(out);
+    expect(vecReset(4, 5, out)).toBe(out);
   });
 });

--- a/src/__test__/vecFunctions/vecScale.spec.ts
+++ b/src/__test__/vecFunctions/vecScale.spec.ts
@@ -1,21 +1,14 @@
-import { vecReset } from "../../vecFunctions/vecReset";
 import { vecScale } from "../../vecFunctions/vecScale";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecScale", () => {
-  it("3(6,2) => (18,6)", () => {
-    expectVecEqualsApprox(vecScale(vecReset(6, 2), 3), vecReset(18, 6));
-  });
-
-  it("-3(6,-2) => (-18,6)", () => {
-    expectVecEqualsApprox(vecScale(vecReset(6, -2), -3), vecReset(-18, 6));
-  });
-
-  it("NaN(6,-2) => (NaN,NaN)", () => {
-    expectVecEqualsApprox(vecScale(vecReset(6, -2), NaN), vecReset(NaN, NaN));
-  });
-
-  it("0(4,5) => (0,0)", () => {
-    expectVecEqualsApprox(vecScale(vecReset(4, 5), 0), vecReset(0, 0));
+  it.each`
+    vec        | scalar | result
+    ${[6, 2]}  | ${3}   | ${[18, 6]}
+    ${[6, -2]} | ${-3}  | ${[-18, 6]}
+    ${[6, -2]} | ${NaN} | ${[NaN, NaN]}
+    ${[4, 5]}  | ${0}   | ${[0, 0]}
+  `("$vec $scalar => $result", ({ vec, scalar, result }) => {
+    expectVecEqualsApprox(vecScale(_vec(vec), scalar), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecSubtract.spec.ts
+++ b/src/__test__/vecFunctions/vecSubtract.spec.ts
@@ -1,9 +1,11 @@
-import { vecReset } from "../../vecFunctions/vecReset";
 import { vecSubtract } from "../../vecFunctions/vecSubtract";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _vec } from "../helpers";
 
 describe("vecSubtract", () => {
-  it("(4,5) - (20,30) => (-16,-25)", () => {
-    expectVecEqualsApprox(vecSubtract(vecReset(4, 5), vecReset(20, 30)), vecReset(-16, -25));
+  it.each`
+    v0        | v1          | result
+    ${[4, 5]} | ${[20, 30]} | ${[-16, -25]}
+  `("$v0 $v1 => $result", ({ v0, v1, result }) => {
+    expectVecEqualsApprox(vecSubtract(_vec(v0), _vec(v1)), _vec(result));
   });
 });

--- a/src/__test__/vecFunctions/vecTransformBy.spec.ts
+++ b/src/__test__/vecFunctions/vecTransformBy.spec.ts
@@ -1,19 +1,13 @@
-import { mat2dIdentity } from "../../mat2dFunctions/mat2dIdentity";
-import { mat2dReset } from "../../mat2dFunctions/mat2dReset";
-import { vecReset } from "../../vecFunctions/vecReset";
 import { vecTransformBy } from "../../vecFunctions/vecTransformBy";
-import { expectVecEqualsApprox } from "../helpers";
+import { expectVecEqualsApprox, _mat2d, _vec } from "../helpers";
 
 describe("vecTransformBy", () => {
-  it("[1 0 0 1 0 0](3, 4) => (3, 4)", () => {
-    expectVecEqualsApprox(vecTransformBy(vecReset(3, 4), mat2dIdentity()), vecReset(3, 4));
-  });
-
-  it("[2 0 0 2 10 20](3, 4) => (16,28)", () => {
-    expectVecEqualsApprox(vecTransformBy(vecReset(3, 4), mat2dReset(2, 0, 0, 2, 10, 20)), vecReset(16, 28));
-  });
-
-  it("[0 -1 1 0 10 20](3, 4) => (14,17)", () => {
-    expectVecEqualsApprox(vecTransformBy(vecReset(3, 4), mat2dReset(0, -1, 1, 0, 10, 20)), vecReset(14, 17));
+  it.each`
+    vec       | mat                      | result
+    ${[3, 4]} | ${[1, 0, 0, 1, 0, 0]}    | ${[3, 4]}
+    ${[3, 4]} | ${[2, 0, 0, 2, 10, 20]}  | ${[16, 28]}
+    ${[3, 4]} | ${[0, -1, 1, 0, 10, 20]} | ${[14, 17]}
+  `("$vec $mat => $result", ({ vec, mat, result }) => {
+    expectVecEqualsApprox(vecTransformBy(_vec(vec), _mat2d(mat)), _vec(result));
   });
 });


### PR DESCRIPTION
Modernizes the code practices used in all the vec* tests to follow latest Jest conventions

Follow up to #29 et al