### PR TITLE
Fix transform error in ray intersection. Add tests

### DIFF
--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -1,11 +1,13 @@
 import { boxReset } from "../boxFunctions/boxReset";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
+import { rayReset } from "../rayFunctions/rayReset";
+import { segmentReset } from "../segmentFunctions/segmentReset";
 import { IBox, IMat2d, IPointIntersectionResult, IVec } from "../types";
 import { vecReset } from "../vecFunctions/vecReset";
 
 export const TEST_PRECISION_DIGITS = 10;
 
-function expectEqualsApprox(actual: number, expected: number) {
+export function expectEqualsApprox(actual: number, expected: number) {
   if (isNaN(expected)) {
     expect(actual).toBeNaN();
   } else if (isFinite(expected)) {
@@ -70,4 +72,17 @@ export function _vec(values: number[]) {
   expect(values).toHaveLength(2);
   const [x, y] = values;
   return vecReset(x, y);
+}
+
+export function _ray(values: number[]) {
+  expect(values).toHaveLength(4);
+  const [x0, y0, dirX, dirY] = values;
+  expectEqualsApprox(dirX * dirX + dirY * dirY, 1);
+  return rayReset(x0, y0, dirX, dirY);
+}
+
+export function _segment(values: number[]) {
+  expect(values).toHaveLength(4);
+  const [x0, y0, x1, y1] = values;
+  return segmentReset(x0, y0, x1, y1);
 }

--- a/src/__test__/rayFunctions/rayIntersectSegment.spec.ts
+++ b/src/__test__/rayFunctions/rayIntersectSegment.spec.ts
@@ -1,0 +1,42 @@
+import { rayIntersectSegment } from "../../rayFunctions/rayIntersectSegment";
+import { expectEqualsApprox, _ray, _segment } from "../helpers";
+
+const SQRT1_2 = Math.SQRT1_2;
+const SQRT2 = Math.SQRT2;
+describe("rayIntersectSegment", () => {
+  it.each`
+    ray             | segment          | t0
+    ${[0, 0, 1, 0]} | ${[6, -5, 6, 5]} | ${6}
+    ${[0, 0, -1, 0]} | ${[-6, -5, -6, 5]} | ${6}
+    ${[0.5, 0.5, 0, 1]} | ${[0, 1, 1, 1]} | ${0.5}
+    ${[0.5, 0.5, 1, 0]} | ${[1, 0, 1, 1]} | ${0.5}
+    ${[0, 0, SQRT1_2, SQRT1_2]} | ${[0, 4, 4, 0]} | ${2 * SQRT2}
+    ${[0, 0, -SQRT1_2, SQRT1_2]} | ${[0, 4, -4, 0]} | ${2 * SQRT2}
+    ${[0, 0, -SQRT1_2, -SQRT1_2]} | ${[0, -4, -4, 0]} | ${2 * SQRT2}
+    ${[0, 0, SQRT1_2, -SQRT1_2]} | ${[0, -4, 4, 0]} | ${2 * SQRT2}
+    ${[5, 10, SQRT1_2, SQRT1_2]} | ${[5, 14, 9, 10]} | ${2 * SQRT2}
+    ${[5, 10, -SQRT1_2, SQRT1_2]} | ${[5, 14, 1, 10]} | ${2 * SQRT2}
+    ${[5, 10, -SQRT1_2, -SQRT1_2]} | ${[5, 6, 1, 10]} | ${2 * SQRT2}
+    ${[5, 10, SQRT1_2, -SQRT1_2]} | ${[5, 6, 9, 10]} | ${2 * SQRT2}
+    ${[0, 0, 1, 0]} | ${[5, 1, 1, 5]} | ${false}
+    ${[0, 0, 0, 1]} | ${[5, 1, 1, 5]} | ${false}
+    ${[0, 0, -1, 0]} | ${[5, 1, 1, 5]} | ${false}
+    ${[0, 0, 0, -1]} | ${[5, 1, 1, 5]} | ${false}
+  `("$ray $segment => $t0", ({ ray, segment, t0 }) => {
+    const actual = rayIntersectSegment(_ray(ray), _segment(segment));
+    if (t0 === false) {
+      expect(actual.exists).toBe(false);
+      expect(actual.t0).toBe(NaN);
+      expect(actual.t1).toBe(NaN);
+      expect(actual.x).toBe(NaN);
+      expect(actual.y).toBe(NaN);
+    } else {
+      const _r = _ray(ray);
+      expectEqualsApprox(actual.t0, t0);
+      // TODO: test `t1`
+      expectEqualsApprox(actual.x, _r.x0 + t0 * _r.dirX);
+      expectEqualsApprox(actual.y, _r.y0 + t0 * _r.dirY);
+    }
+  });
+});
+

--- a/src/lineFunctions/lineIntersectLine.ts
+++ b/src/lineFunctions/lineIntersectLine.ts
@@ -1,7 +1,7 @@
+import { EPSILON } from "../internal/const";
 import { _dot } from "../internal/_dot";
 import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lineTransformByOrtho } from "../internal/_lineTransformByOrtho";
-import { EPSILON } from "../internal/const";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { pointIntersectionResultAlloc } from "../pointIntersectionResultFunctions/pointIntersectionResultAlloc";
 import { pointIntersectionResultReset } from "../pointIntersectionResultFunctions/pointIntersectionResultReset";
@@ -34,7 +34,16 @@ import { lineGetPointAt } from "./lineGetPointAt";
  * @see {@link lineIntersectSegment}
  */
 export function lineIntersectLine(a: ILine, b: ILine, out = pointIntersectionResultAlloc()) {
-  const transform = mat2dReset(a.dirX, -a.dirY, a.dirY, a.dirX, -a.x0, -a.y0);
+  // [dirX -dirY dirY dirX 0 0 ] [1 0 0 1 -x0 -y0]  = [ -x0 * dirX - y0 * dirY  / [x0 * dirY - y0 * dirX]
+  const transform = mat2dReset(
+    a.dirX,
+    -a.dirY,
+    a.dirY,
+    a.dirX,
+    -a.x0 * a.dirX - a.y0 * a.dirY,
+    a.x0 * a.dirY - a.y0 * a.dirX,
+  );
+
   const localB = _lineTransformByOrtho(b, transform);
   const isParallel = Math.abs(localB.dirY) < EPSILON;
 


### PR DESCRIPTION
Fixes a very bad error in ray-ray intersection computation where the second ray `b` was not being transformed by the appropriate matrix to compute its parameters in space local to the first ray `a`. This resulted in all kinds of strange behavior, such as intersections not being found at all or being found in the completely wrong place.

Fixes #23 