### PR TITLE
Remove "I" naming prefix from all public types

### DIFF
--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -2,7 +2,7 @@ import { boxReset } from "../boxFunctions/boxReset";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { rayReset } from "../rayFunctions/rayReset";
 import { segmentReset } from "../segmentFunctions/segmentReset";
-import { IBox, IMat2d, IIntersectionResult, IVec } from "../types";
+import { Box, Mat2d, IntersectionResult, Vec } from "../types";
 import { vecReset } from "../vecFunctions/vecReset";
 
 export const TEST_PRECISION_DIGITS = 10;
@@ -17,19 +17,19 @@ export function expectEqualsApprox(actual: number, expected: number) {
   }
 }
 
-export function expectBoxEqualsApprox(box: IBox, expected: IBox) {
+export function expectBoxEqualsApprox(box: Box, expected: Box) {
   expectEqualsApprox(box.minX, expected.minX);
   expectEqualsApprox(box.minY, expected.minY);
   expectEqualsApprox(box.maxX, expected.maxX);
   expectEqualsApprox(box.maxY, expected.maxY);
 }
 
-export function expectVecEqualsApprox(actual: IVec, expected: IVec) {
+export function expectVecEqualsApprox(actual: Vec, expected: Vec) {
   expectEqualsApprox(actual.x, expected.x);
   expectEqualsApprox(actual.y, expected.y);
 }
 
-export function expectIntersectionEqualsApprox(actual: IIntersectionResult, expected: IIntersectionResult) {
+export function expectIntersectionEqualsApprox(actual: IntersectionResult, expected: IntersectionResult) {
   expect(actual.exists).toBe(expected.exists);
   expectEqualsApprox(actual.x, expected.x);
   expectEqualsApprox(actual.y, expected.y);
@@ -37,7 +37,7 @@ export function expectIntersectionEqualsApprox(actual: IIntersectionResult, expe
   expectEqualsApprox(actual.t1, expected.t1);
 }
 
-export function expectIntersectionDNE(intersection: IIntersectionResult) {
+export function expectIntersectionDNE(intersection: IntersectionResult) {
   expect(intersection).toEqual({
     exists: false,
     x: NaN,
@@ -47,7 +47,7 @@ export function expectIntersectionDNE(intersection: IIntersectionResult) {
   });
 }
 
-export function expectMat2dEqualsApprox(actual: IMat2d, expected: IMat2d) {
+export function expectMat2dEqualsApprox(actual: Mat2d, expected: Mat2d) {
   expectEqualsApprox(actual.a, expected.a);
   expectEqualsApprox(actual.b, expected.b);
   expectEqualsApprox(actual.c, expected.c);

--- a/src/boxFunctions/boxAlloc.ts
+++ b/src/boxFunctions/boxAlloc.ts
@@ -1,6 +1,6 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 
-class Box implements IBox {
+class _Box implements Box {
   public minX = NaN;
   public minY = NaN;
   public maxX = NaN;
@@ -28,6 +28,6 @@ class Box implements IBox {
  *    const result = polygonGetBounds(existingObj.geometry, TMP0);
  *  }
  */
-export function boxAlloc(): IBox {
-  return new Box();
+export function boxAlloc(): Box {
+  return new _Box();
 }

--- a/src/boxFunctions/boxClone.ts
+++ b/src/boxFunctions/boxClone.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -17,6 +17,6 @@ import { boxReset } from "./boxReset";
  *  const TMP_BOX = boxAlloc();
  *  boxClone(myBox, TMP_BOX);
  */
-export function boxClone(box: IBox, out = boxAlloc()) {
+export function boxClone(box: Box, out = boxAlloc()) {
   return boxReset(box.minX, box.minY, box.maxX, box.maxY, out);
 }

--- a/src/boxFunctions/boxContainsBox.ts
+++ b/src/boxFunctions/boxContainsBox.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 
 /**
  * Determines whether the second box is completely enclosed in the first.
@@ -10,6 +10,6 @@ import { IBox } from "../types";
  * @param a
  * @param b
  */
-export function boxContainsBox(a: IBox, b: IBox) {
+export function boxContainsBox(a: Box, b: Box) {
   return b.minX >= a.minX && b.minY >= a.minY && b.maxX <= a.maxX && b.maxY <= a.maxY;
 }

--- a/src/boxFunctions/boxContainsPoint.ts
+++ b/src/boxFunctions/boxContainsPoint.ts
@@ -1,5 +1,5 @@
 import { IntervalMode } from "../const";
-import { IBox, IVec } from "../types";
+import { Box, Vec } from "../types";
 
 /**
  * Determines whether the box contains a given point.
@@ -11,7 +11,7 @@ import { IBox, IVec } from "../types";
  * @param box
  * @param point
  */
-export function boxContainsPoint(box: IBox, point: IVec, mode: IntervalMode) {
+export function boxContainsPoint(box: Box, point: Vec, mode: IntervalMode) {
   switch (mode) {
     case IntervalMode.OPEN:
       return point.x > box.minX && point.y > box.minY && point.x < box.maxX && point.y < box.maxY;

--- a/src/boxFunctions/boxEncapsulate.ts
+++ b/src/boxFunctions/boxEncapsulate.ts
@@ -1,4 +1,4 @@
-import { IBox, IVec } from "../types";
+import { Box, Vec } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -12,7 +12,7 @@ import { boxReset } from "./boxReset";
  * @param point the point that the box should grow to include
  * @param out
  */
-export function boxEncapsulate(box: IBox, point: IVec, out = boxAlloc()) {
+export function boxEncapsulate(box: Box, point: Vec, out = boxAlloc()) {
   return boxReset(
     Math.min(box.minX, point.x),
     Math.min(box.minY, point.y),

--- a/src/boxFunctions/boxEnclosingPoints.ts
+++ b/src/boxFunctions/boxEnclosingPoints.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -11,7 +11,7 @@ import { boxReset } from "./boxReset";
  * @param points the points to contain
  * @param out
  */
-export function boxEnclosingPoints(points: IVec[], out = boxAlloc()) {
+export function boxEnclosingPoints(points: Vec[], out = boxAlloc()) {
   let minX: number = Infinity;
   let minY: number = Infinity;
   let maxX: number = -Infinity;

--- a/src/boxFunctions/boxGetOutCode.ts
+++ b/src/boxFunctions/boxGetOutCode.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-bitwise
 import { Out } from "../const";
-import { IBox, IVec } from "../types";
+import { Box, Vec } from "../types";
 
 /**
  * Determines where the specified point lies in relation to the given box.
@@ -21,7 +21,7 @@ import { IBox, IVec } from "../types";
  * __see Out.MIN_Y
  * __see Out.MAX_Y
  */
-export function boxGetOutCode(box: IBox, point: IVec) {
+export function boxGetOutCode(box: Box, point: Vec) {
   let out = 0;
   if (point.x < box.minX) {
     out |= Out.MIN_X;

--- a/src/boxFunctions/boxGrow.ts
+++ b/src/boxFunctions/boxGrow.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -13,6 +13,6 @@ import { boxReset } from "./boxReset";
  * @param amount amount to expand from each edge. Is allowed to be negative.
  * @param out
  */
-export function boxGrow(box: IBox, amount: number, out = boxAlloc()) {
+export function boxGrow(box: Box, amount: number, out = boxAlloc()) {
   return boxReset(box.minX - amount, box.minY - amount, box.maxX + amount, box.maxY + amount, out);
 }

--- a/src/boxFunctions/boxIntersection.ts
+++ b/src/boxFunctions/boxIntersection.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -17,7 +17,7 @@ import { boxReset } from "./boxReset";
  * @param out
  * __see {@link boxUnion}
  */
-export function boxIntersection(a: IBox, b: IBox, out = boxAlloc()) {
+export function boxIntersection(a: Box, b: Box, out = boxAlloc()) {
   return boxReset(
     Math.max(a.minX, b.minX),
     Math.max(a.minY, b.minY),

--- a/src/boxFunctions/boxIntersectsBox.ts
+++ b/src/boxFunctions/boxIntersectsBox.ts
@@ -1,5 +1,5 @@
 import { IntervalMode } from "../const";
-import { IBox } from "../types";
+import { Box } from "../types";
 
 /**
  * Determines whether two boxes overlap.
@@ -13,7 +13,7 @@ import { IBox } from "../types";
  * @param b second box to check for overlap
  * @param mode whether to include the boundaries of the boxes
  */
-export function boxIntersectsBox(a: IBox, b: IBox, mode: IntervalMode) {
+export function boxIntersectsBox(a: Box, b: Box, mode: IntervalMode) {
   switch (mode) {
     case IntervalMode.OPEN:
     case IntervalMode.OPEN_ABOVE:

--- a/src/boxFunctions/boxIsEmpty.ts
+++ b/src/boxFunctions/boxIsEmpty.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 
 /**
  * Determines whether this box represents an empty area.
@@ -13,7 +13,7 @@ import { IBox } from "../types";
  *
  * @param box
  */
-export function boxIsEmpty(box: IBox) {
+export function boxIsEmpty(box: Box) {
   // Remark: prefer this comparison over distributing the ! to handle NaNs.
   return !(box.maxX > box.minX && box.maxY > box.minY);
 }

--- a/src/boxFunctions/boxScale.ts
+++ b/src/boxFunctions/boxScale.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -9,6 +9,6 @@ import { boxReset } from "./boxReset";
  * @param scalar the value by which to multiply all of the box's components
  * @param out
  */
-export function boxScale(box: IBox, scalar: number, out = boxAlloc()) {
+export function boxScale(box: Box, scalar: number, out = boxAlloc()) {
   return boxReset(box.minX * scalar, box.minY * scalar, box.maxX * scalar, box.maxY * scalar, out);
 }

--- a/src/boxFunctions/boxTransformBy.ts
+++ b/src/boxFunctions/boxTransformBy.ts
@@ -1,7 +1,7 @@
 import { _arrayReset } from "../internal/_arrayReset";
 import { polylineGetBounds } from "../polylineFunctions/polylineGetBounds";
 import { polylineTransformBy } from "../polylineFunctions/polylineTransformBy";
-import { IBox, IMat2d, IPolyline } from "../types";
+import { Box, Mat2d, Polyline } from "../types";
 import { boxAlloc } from "./boxAlloc";
 
 /**
@@ -17,8 +17,8 @@ import { boxAlloc } from "./boxAlloc";
  * @param mat the affine transformation to apply to the box
  * @param out
  */
-export function boxTransformBy(box: IBox, mat: IMat2d, out = boxAlloc()) {
-  const tmp = [] as IPolyline;
+export function boxTransformBy(box: Box, mat: Mat2d, out = boxAlloc()) {
+  const tmp = [] as Polyline;
   _arrayReset(tmp, box.minX, box.minY, box.minX, box.maxY, box.maxX, box.maxY, box.maxX, box.minY);
   polylineTransformBy(tmp, mat, tmp);
   return polylineGetBounds(tmp, out);

--- a/src/boxFunctions/boxTranslate.ts
+++ b/src/boxFunctions/boxTranslate.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -10,6 +10,6 @@ import { boxReset } from "./boxReset";
  * @param ty the amount to translate in the y direction
  * @param out
  */
-export function boxTranslate(box: IBox, tx: number, ty: number, out = boxAlloc()) {
+export function boxTranslate(box: Box, tx: number, ty: number, out = boxAlloc()) {
   return boxReset(box.minX + tx, box.minY + ty, box.maxX + tx, box.maxY + ty, out);
 }

--- a/src/boxFunctions/boxUnion.ts
+++ b/src/boxFunctions/boxUnion.ts
@@ -1,4 +1,4 @@
-import { IBox } from "../types";
+import { Box } from "../types";
 import { boxAlloc } from "./boxAlloc";
 import { boxReset } from "./boxReset";
 
@@ -12,7 +12,7 @@ import { boxReset } from "./boxReset";
  * @param b
  * @param out
  */
-export function boxUnion(a: IBox, b: IBox, out = boxAlloc()) {
+export function boxUnion(a: Box, b: Box, out = boxAlloc()) {
   return boxReset(
     Math.min(a.minX, b.minX),
     Math.min(a.minY, b.minY),

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export { segmentNearestDistanceSqToPoint } from "./segmentFunctions/segmentNeare
 export { segmentReset } from "./segmentFunctions/segmentReset";
 export { segmentReverse } from "./segmentFunctions/segmentReverse";
 export { _segment } from "./segmentFunctions/_segment";
-export { IBox, IIntersectionResult, IMat2d, IPolyline, IRay, ISegment, IVec } from "./types";
+export { Box, IntersectionResult, Mat2d, Polyline, Ray, Segment, Vec } from "./types";
 export { vecAdd } from "./vecFunctions/vecAdd";
 export { vecAlloc } from "./vecFunctions/vecAlloc";
 export { vecClone } from "./vecFunctions/vecClone";

--- a/src/internal/_dot.ts
+++ b/src/internal/_dot.ts
@@ -1,5 +1,5 @@
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 
-export function _dot(ray: IRay, vec: IVec) {
+export function _dot(ray: Ray, vec: Vec) {
   return ray.dirX * (vec.x - ray.x0) + ray.dirY * (vec.y - ray.y0);
 }

--- a/src/internal/_dotPerp.ts
+++ b/src/internal/_dotPerp.ts
@@ -1,5 +1,5 @@
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 
-export function _dotPerp(ray: IRay, point: IVec) {
+export function _dotPerp(ray: Ray, point: Vec) {
   return ray.dirX * (point.y - ray.y0) - ray.dirY * (point.x - ray.x0);
 }

--- a/src/internal/_intersectionDNE.ts
+++ b/src/internal/_intersectionDNE.ts
@@ -1,6 +1,6 @@
-import { IIntersectionResult } from "../types";
+import { IntersectionResult } from "../types";
 
-export function _intersectionDNE(out: IIntersectionResult) {
+export function _intersectionDNE(out: IntersectionResult) {
   out.exists = false;
   out.x = out.y = out.t0 = out.t1 = NaN;
   return out;

--- a/src/internal/_intersectionSwapTs.ts
+++ b/src/internal/_intersectionSwapTs.ts
@@ -1,6 +1,6 @@
-import { IIntersectionResult } from "../types";
+import { IntersectionResult } from "../types";
 
-export function _intersectionSwapTs(out: IIntersectionResult) {
+export function _intersectionSwapTs(out: IntersectionResult) {
   const tmp = out.t0;
   out.t0 = out.t1;
   out.t1 = tmp;

--- a/src/internal/_lookAt.ts
+++ b/src/internal/_lookAt.ts
@@ -1,9 +1,9 @@
 import { rayAlloc } from "../rayFunctions/rayAlloc";
 import { rayReset } from "../rayFunctions/rayReset";
-import { IRay } from "../types";
+import { Ray } from "../types";
 import { EPSILON_SQ } from "./const";
 
-export function _lookAt(x0: number, y0: number, x1: number, y1: number, out: IRay = rayAlloc()) {
+export function _lookAt(x0: number, y0: number, x1: number, y1: number, out: Ray = rayAlloc()) {
   const dx = x1 - x0;
   const dy = y1 - y0;
   const lenSq = dx * dx + dy * dy;

--- a/src/internal/_polylineIntersectHelper.ts
+++ b/src/internal/_polylineIntersectHelper.ts
@@ -3,18 +3,18 @@ import { intersectionResultReset } from "../intersectionResultFunctions/intersec
 import { polylineGetNumSegments } from "../polylineFunctions/polylineGetNumSegments";
 import { polylineGetSegment } from "../polylineFunctions/polylineGetSegment";
 import { segmentAlloc } from "../segmentFunctions/segmentAlloc";
-import { IIntersectionResult, IPolyline, ISegment } from "../types";
+import { IntersectionResult, Polyline, Segment } from "../types";
 
 
 export function _polylineIntersectHelper<T>(
-  poly: IPolyline,
+  poly: Polyline,
   value: T,
-  doIntersectSegment: (segment: ISegment, value: T, out: IIntersectionResult) => IIntersectionResult,
+  doIntersectSegment: (segment: Segment, value: T, out: IntersectionResult) => IntersectionResult,
 ) {
   const tmp0 = segmentAlloc();
   const tmp1 = intersectionResultAlloc();
 
-  const allIntersections: IIntersectionResult[] = [];
+  const allIntersections: IntersectionResult[] = [];
   const numSegments = polylineGetNumSegments(poly);
   // prevent repeated intersections at the same vertex in successive segments
   let lastIntersection = NaN;

--- a/src/internal/_rayTransformByOrtho.ts
+++ b/src/internal/_rayTransformByOrtho.ts
@@ -1,10 +1,10 @@
 import { rayAlloc } from "../rayFunctions/rayAlloc";
 import { rayReset } from "../rayFunctions/rayReset";
-import { IMat2d, IRay } from "../types";
+import { Mat2d, Ray } from "../types";
 import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
 
-export function _rayTransformByOrtho(ray: IRay, mat: IMat2d, out: IRay = rayAlloc()) {
+export function _rayTransformByOrtho(ray: Ray, mat: Mat2d, out: Ray = rayAlloc()) {
   const initial = vecReset(ray.x0, ray.y0);
   vecTransformBy(initial, mat, initial);
   return rayReset(initial.x, initial.y, mat.a * ray.dirX + mat.c * ray.dirY, mat.b * ray.dirX + mat.d * ray.dirY, out);

--- a/src/internal/_swapAndReorderIntersections.ts
+++ b/src/internal/_swapAndReorderIntersections.ts
@@ -1,11 +1,11 @@
-import { IIntersectionResult } from "../types";
+import { IntersectionResult } from "../types";
 import { _intersectionSwapTs } from "./_intersectionSwapTs";
 
-function sortByT0Increasing(a: IIntersectionResult, b: IIntersectionResult) {
+function sortByT0Increasing(a: IntersectionResult, b: IntersectionResult) {
   return a.t0 < b.t0 ? -1 : a.t0 > b.t0 ? 1 : 0;
 }
 
-export function _swapAndReorderIntersections(intersections: IIntersectionResult[]) {
+export function _swapAndReorderIntersections(intersections: IntersectionResult[]) {
   intersections.forEach(_intersectionSwapTs);
   intersections.sort(sortByT0Increasing);
   return intersections;

--- a/src/intersectionResultFunctions/intersectionResultAlloc.ts
+++ b/src/intersectionResultFunctions/intersectionResultAlloc.ts
@@ -1,6 +1,6 @@
-import { IIntersectionResult } from "../types";
+import { IntersectionResult } from "../types";
 
-class IntersectionResult implements IIntersectionResult {
+class IntersectionResult implements IntersectionResult {
   public exists = false;
   public x = NaN;
   public y = NaN;
@@ -13,6 +13,6 @@ class IntersectionResult implements IIntersectionResult {
  * This is useful to hold the result of math2d function calls in performance
  * critical workflows.
  */
-export function intersectionResultAlloc(): IIntersectionResult {
+export function intersectionResultAlloc(): IntersectionResult {
   return new IntersectionResult();
 }

--- a/src/intersectionResultFunctions/intersectionResultAlloc.ts
+++ b/src/intersectionResultFunctions/intersectionResultAlloc.ts
@@ -1,6 +1,6 @@
 import { IntersectionResult } from "../types";
 
-class IntersectionResult implements IntersectionResult {
+class _IntersectionResult implements IntersectionResult {
   public exists = false;
   public x = NaN;
   public y = NaN;
@@ -14,5 +14,5 @@ class IntersectionResult implements IntersectionResult {
  * critical workflows.
  */
 export function intersectionResultAlloc(): IntersectionResult {
-  return new IntersectionResult();
+  return new _IntersectionResult();
 }

--- a/src/intersectionResultFunctions/intersectionResultClone.ts
+++ b/src/intersectionResultFunctions/intersectionResultClone.ts
@@ -1,4 +1,4 @@
-import { IIntersectionResult } from "../types";
+import { IntersectionResult } from "../types";
 import { intersectionResultAlloc } from "./intersectionResultAlloc";
 import { intersectionResultReset } from "./intersectionResultReset";
 
@@ -8,7 +8,7 @@ import { intersectionResultReset } from "./intersectionResultReset";
  * @param out
  */
 export function intersectionResultClone(
-  intersection: IIntersectionResult,
+  intersection: IntersectionResult,
   out = intersectionResultAlloc(),
 ) {
   return intersectionResultReset(

--- a/src/mat2dFunctions/mat2dAlloc.ts
+++ b/src/mat2dFunctions/mat2dAlloc.ts
@@ -1,6 +1,6 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 
-class Mat2d implements IMat2d {
+class _Mat2d implements Mat2d {
   public a = NaN;
   public b = NaN;
   public c = NaN;
@@ -30,6 +30,6 @@ class Mat2d implements IMat2d {
  *    const result = mat2dInvert(existingObj.transform, TMP0);
  *  }
  */
-export function mat2dAlloc(): IMat2d {
-  return new Mat2d();
+export function mat2dAlloc(): Mat2d {
+  return new _Mat2d();
 }

--- a/src/mat2dFunctions/mat2dClone.ts
+++ b/src/mat2dFunctions/mat2dClone.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -8,6 +8,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param mat the matrix to copy
  * @param out
  */
-export function mat2dClone(mat: IMat2d, out = mat2dAlloc()) {
+export function mat2dClone(mat: Mat2d, out = mat2dAlloc()) {
   return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.e, mat.f, out);
 }

--- a/src/mat2dFunctions/mat2dDeterminant.ts
+++ b/src/mat2dFunctions/mat2dDeterminant.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 
 /**
  * Computes the determinant of the affine matrix
@@ -7,6 +7,6 @@ import { IMat2d } from "../types";
  *
  * @param mat matrix to take determinant of
  */
-export function mat2dDeterminant(mat: IMat2d) {
+export function mat2dDeterminant(mat: Mat2d) {
   return mat.a * mat.d - mat.b * mat.c;
 }

--- a/src/mat2dFunctions/mat2dInvert.ts
+++ b/src/mat2dFunctions/mat2dInvert.ts
@@ -1,5 +1,5 @@
 import { EPSILON } from "../internal/const";
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -9,7 +9,7 @@ import { mat2dReset } from "./mat2dReset";
  * @param mat the matrix to invert
  * @param out
  */
-export function mat2dInvert(mat: IMat2d, out = mat2dAlloc()) {
+export function mat2dInvert(mat: Mat2d, out = mat2dAlloc()) {
   const det = mat.a * mat.d - mat.b * mat.c;
   if (det > -EPSILON && det < EPSILON) {
     return mat2dReset(NaN, NaN, NaN, NaN, NaN, NaN, out);

--- a/src/mat2dFunctions/mat2dIsOrthogonal.ts
+++ b/src/mat2dFunctions/mat2dIsOrthogonal.ts
@@ -1,5 +1,5 @@
 import { EPSILON, EPSILON_SQ } from "../internal/const";
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 
 /**
  * Returns whether the matrix is an orthogonal matrix.
@@ -13,7 +13,7 @@ import { IMat2d } from "../types";
  * @param mat the matrix to check for orthogonality
  * __see {@link mat2dIsTranslationOnly}
  */
-export function mat2dIsOrthogonal(mat: IMat2d) {
+export function mat2dIsOrthogonal(mat: Mat2d) {
   const d1Sq = mat.a * mat.a + mat.b * mat.b;
   const d2Sq = mat.c * mat.c + mat.d * mat.d;
   const dot = mat.a * mat.c + mat.b * mat.d;

--- a/src/mat2dFunctions/mat2dIsTranslationOnly.ts
+++ b/src/mat2dFunctions/mat2dIsTranslationOnly.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 
 /**
  * Returns whether the matrix corresponds to only a translation.
@@ -13,6 +13,6 @@ import { IMat2d } from "../types";
  * @param mat the matrix to inspect
  * __see {@link mat2dIsOrthogonal}
  */
-export function mat2dIsTranslationOnly(mat: IMat2d) {
+export function mat2dIsTranslationOnly(mat: Mat2d) {
   return mat.a === 1 && mat.b === 0 && mat.c === 0 && mat.d === 1;
 }

--- a/src/mat2dFunctions/mat2dMulMat2d.ts
+++ b/src/mat2dFunctions/mat2dMulMat2d.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -30,7 +30,7 @@ import { mat2dReset } from "./mat2dReset";
  * __see {@link IMatrix}
  * __see {@link vecTransformBy}
  */
-export function mat2dMulMat2d(m1: IMat2d, m2: IMat2d, out = mat2dAlloc()) {
+export function mat2dMulMat2d(m1: Mat2d, m2: Mat2d, out = mat2dAlloc()) {
   const a = m1.a * m2.a + m1.c * m2.b;
   const b = m1.b * m2.a + m1.d * m2.b;
   const c = m1.a * m2.c + m1.c * m2.d;

--- a/src/mat2dFunctions/mat2dRotate.ts
+++ b/src/mat2dFunctions/mat2dRotate.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -19,7 +19,7 @@ import { mat2dReset } from "./mat2dReset";
  * __see {@link mat2dFromRotation}
  * __see {@link mat2dMulMat2d}
  */
-export function mat2dRotate(mat: IMat2d, theta: number, out = mat2dAlloc()) {
+export function mat2dRotate(mat: Mat2d, theta: number, out = mat2dAlloc()) {
   const cos = Math.cos(theta);
   const sin = Math.sin(theta);
   return mat2dReset(

--- a/src/mat2dFunctions/mat2dScale.ts
+++ b/src/mat2dFunctions/mat2dScale.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -16,6 +16,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param out
  * __see {@link mat2dMulMat2d}
  */
-export function mat2dScale(mat: IMat2d, scale: number, out = mat2dAlloc()) {
+export function mat2dScale(mat: Mat2d, scale: number, out = mat2dAlloc()) {
   return mat2dReset(scale * mat.a, scale * mat.b, scale * mat.c, scale * mat.d, scale * mat.e, scale * mat.f, out);
 }

--- a/src/mat2dFunctions/mat2dTranslate.ts
+++ b/src/mat2dFunctions/mat2dTranslate.ts
@@ -1,4 +1,4 @@
-import { IMat2d } from "../types";
+import { Mat2d } from "../types";
 import { mat2dAlloc } from "./mat2dAlloc";
 import { mat2dReset } from "./mat2dReset";
 
@@ -16,6 +16,6 @@ import { mat2dReset } from "./mat2dReset";
  * __see {@link mat2dFromTranslation}
  * __see {@link mat2dMulMat2d}
  */
-export function mat2dTranslate(mat: IMat2d, tx: number, ty: number, out = mat2dAlloc()) {
+export function mat2dTranslate(mat: Mat2d, tx: number, ty: number, out = mat2dAlloc()) {
   return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.e + tx, mat.f + ty, out);
 }

--- a/src/nearestPointResultFunctions/nearestPointResultAlloc.ts
+++ b/src/nearestPointResultFunctions/nearestPointResultAlloc.ts
@@ -1,6 +1,6 @@
-import { INearestPointResult } from "../types";
+import { NearestPointResult } from "../types";
 
-class NearestPointResult implements INearestPointResult {
+class _NearestPointResult implements NearestPointResult {
   public x = NaN;
   public y = NaN;
   public t = NaN;
@@ -12,6 +12,6 @@ class NearestPointResult implements INearestPointResult {
  * This is useful to hold the result of math2d function calls in performance
  * critical workflows.
  */
-export function nearestPointResultAlloc(): INearestPointResult {
-  return new NearestPointResult();
+export function nearestPointResultAlloc(): NearestPointResult {
+  return new _NearestPointResult();
 }

--- a/src/nearestPointResultFunctions/nearestPointResultClone.ts
+++ b/src/nearestPointResultFunctions/nearestPointResultClone.ts
@@ -1,4 +1,4 @@
-import { INearestPointResult } from "../types";
+import { NearestPointResult } from "../types";
 import { nearestPointResultAlloc } from "./nearestPointResultAlloc";
 import { nearestPointResultReset } from "./nearestPointResultReset";
 
@@ -8,7 +8,7 @@ import { nearestPointResultReset } from "./nearestPointResultReset";
  * @param nearestPointResult
  * @param out
  */
-export function nearestPointResultClone(nearestPointResult: INearestPointResult, out = nearestPointResultAlloc()) {
+export function nearestPointResultClone(nearestPointResult: NearestPointResult, out = nearestPointResultAlloc()) {
   return nearestPointResultReset(
     nearestPointResult.x,
     nearestPointResult.y,

--- a/src/polylineFunctions/polylineAlloc.ts
+++ b/src/polylineFunctions/polylineAlloc.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Creates a new Array object in memory to hold Polyline data.
@@ -22,6 +22,6 @@ import { IPolyline } from "../types";
  *    const result = polylineTransformBy(existingObj.path, existingObj.transform, TMP0);
  *  }
  */
-export function polylineAlloc(): IPolyline {
+export function polylineAlloc(): Polyline {
   return [];
 }

--- a/src/polylineFunctions/polylineClose.ts
+++ b/src/polylineFunctions/polylineClose.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { polylineAlloc } from "./polylineAlloc";
 
 /**
@@ -7,7 +7,7 @@ import { polylineAlloc } from "./polylineAlloc";
  * @param poly
  * @param out
  */
-export function polylineClose(poly: IPolyline, out = polylineAlloc()) {
+export function polylineClose(poly: Polyline, out = polylineAlloc()) {
   const len = poly.length;
   if (len === 0) {
     out.length = 0;

--- a/src/polylineFunctions/polylineContainsPoint.ts
+++ b/src/polylineFunctions/polylineContainsPoint.ts
@@ -1,7 +1,7 @@
 import { EPSILON_SQ } from "../internal/const";
-import { IPolyline, IVec } from "../types";
+import { Polyline, Vec } from "../types";
 import { polylineNearestDistanceSqToPoint } from "./polylineNearestDistanceSqToPoint";
 
-export function polylineContainsPoint(polyline: IPolyline, point: IVec) {
+export function polylineContainsPoint(polyline: Polyline, point: Vec) {
   return polylineNearestDistanceSqToPoint(polyline, point).distanceValue < EPSILON_SQ;
 }

--- a/src/polylineFunctions/polylineContainsPointInside.ts
+++ b/src/polylineFunctions/polylineContainsPointInside.ts
@@ -1,4 +1,4 @@
-import { IPolyline, IVec } from "../types";
+import { Polyline, Vec } from "../types";
 
 /**
  * Determines whether the point is inside the given polygon, using the even-odd fill rule.
@@ -6,7 +6,7 @@ import { IPolyline, IVec } from "../types";
  * @param poly the polygon to inspect
  * @param point the point to check for containment
  */
-export function polylineContainsPointInside(poly: IPolyline, point: IVec) {
+export function polylineContainsPointInside(poly: Polyline, point: Vec) {
   const x = point.x;
   const y = point.y;
 

--- a/src/polylineFunctions/polylineGetBounds.ts
+++ b/src/polylineFunctions/polylineGetBounds.ts
@@ -1,7 +1,7 @@
 import { boxAlloc } from "../boxFunctions/boxAlloc";
 import { boxEncapsulate } from "../boxFunctions/boxEncapsulate";
 import { boxReset } from "../boxFunctions/boxReset";
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -11,7 +11,7 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param poly
  * @param out
  */
-export function polylineGetBounds(poly: IPolyline, out = boxAlloc()) {
+export function polylineGetBounds(poly: Polyline, out = boxAlloc()) {
   const tmp0 = vecAlloc();
   boxReset(Infinity, Infinity, -Infinity, -Infinity, out);
   for (let i = 0; i < poly.length; i += 2) {

--- a/src/polylineFunctions/polylineGetDistanceAtT.ts
+++ b/src/polylineFunctions/polylineGetDistanceAtT.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
 
@@ -17,7 +17,7 @@ import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
  * __see {@link IPolyline}
  * __see {@link polylineGetTAtDistance}
  */
-export function polylineGetDistanceAtT(polyline: IPolyline, t: number) {
+export function polylineGetDistanceAtT(polyline: Polyline, t: number) {
   const numSegments = polylineGetNumSegments(polyline);
   let traveled = 0;
   for (let i = 0; i < numSegments; i++) {

--- a/src/polylineFunctions/polylineGetLength.ts
+++ b/src/polylineFunctions/polylineGetLength.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
 
@@ -7,7 +7,7 @@ import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
  *
  * @param poly
  */
-export function polylineGetLength(poly: IPolyline) {
+export function polylineGetLength(poly: Polyline) {
   const numSegments = polylineGetNumSegments(poly);
   let length = 0;
   for (let i = 0; i < numSegments; i++) {

--- a/src/polylineFunctions/polylineGetNumSegments.ts
+++ b/src/polylineFunctions/polylineGetNumSegments.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Returns the number of individual line segments in this polyline
@@ -9,6 +9,6 @@ import { IPolyline } from "../types";
  *
  * @param poly
  */
-export function polylineGetNumSegments(poly: IPolyline) {
+export function polylineGetNumSegments(poly: Polyline) {
   return Math.max(0, poly.length / 2 - 1);
 }

--- a/src/polylineFunctions/polylineGetNumVertices.ts
+++ b/src/polylineFunctions/polylineGetNumVertices.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Returns the number of vertices in this polyline
@@ -8,6 +8,6 @@ import { IPolyline } from "../types";
  *
  * @param poly
  */
-export function polylineGetNumVertices(poly: IPolyline) {
+export function polylineGetNumVertices(poly: Polyline) {
   return poly.length / 2;
 }

--- a/src/polylineFunctions/polylineGetPointAtT.ts
+++ b/src/polylineFunctions/polylineGetPointAtT.ts
@@ -1,5 +1,5 @@
 import { _lerp } from "../internal/_lerp";
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
@@ -13,7 +13,7 @@ import { polylineGetNumSegments } from "./polylineGetNumSegments";
  * @param out
  * __see {@link IPolyline}
  */
-export function polylineGetPointAtT(poly: IPolyline, t: number, out = vecAlloc()) {
+export function polylineGetPointAtT(poly: Polyline, t: number, out = vecAlloc()) {
   const maxT = polylineGetNumSegments(poly);
   if (t < 0 || t > maxT) {
     return vecReset(NaN, NaN, out);

--- a/src/polylineFunctions/polylineGetSegment.ts
+++ b/src/polylineFunctions/polylineGetSegment.ts
@@ -1,6 +1,6 @@
 import { segmentAlloc } from "../segmentFunctions/segmentAlloc";
 import { segmentReset } from "../segmentFunctions/segmentReset";
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Returns a polyline's segment by given index, starting at 0.
@@ -9,7 +9,7 @@ import { IPolyline } from "../types";
  * @param index
  * @param out
  */
-export function polylineGetSegment(poly: IPolyline, index: number, out = segmentAlloc()) {
+export function polylineGetSegment(poly: Polyline, index: number, out = segmentAlloc()) {
   const l = 2 * index;
   return segmentReset(poly[l], poly[l + 1], poly[l + 2], poly[l + 3], out);
 }

--- a/src/polylineFunctions/polylineGetSegmentLength.ts
+++ b/src/polylineFunctions/polylineGetSegmentLength.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Computes the length of one of a polyline's segments by index, starting at 0.
@@ -6,7 +6,7 @@ import { IPolyline } from "../types";
  * @param poly
  * @param idx
  */
-export function polylineGetSegmentLength(poly: IPolyline, idx: number) {
+export function polylineGetSegmentLength(poly: Polyline, idx: number) {
   const l = 2 * idx;
   const dx = poly[l + 2] - poly[l];
   const dy = poly[l + 3] - poly[l + 1];

--- a/src/polylineFunctions/polylineGetTAtDistance.ts
+++ b/src/polylineFunctions/polylineGetTAtDistance.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetNumVertices } from "./polylineGetNumVertices";
 import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
@@ -14,7 +14,7 @@ import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
  * __see {@link IPolyline}
  * __see {@link polylineGetDistanceAtT}
  */
-export function polylineGetTAtDistance(poly: IPolyline, d: number) {
+export function polylineGetTAtDistance(poly: Polyline, d: number) {
   if (d < 0) {
     return 0;
   }

--- a/src/polylineFunctions/polylineGetVertex.ts
+++ b/src/polylineFunctions/polylineGetVertex.ts
@@ -1,4 +1,4 @@
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -9,7 +9,7 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param index
  * @param out
  */
-export function polylineGetVertex(poly: IPolyline, index: number, out = vecAlloc()) {
+export function polylineGetVertex(poly: Polyline, index: number, out = vecAlloc()) {
   const l = 2 * index;
   return l >= 0 && l < poly.length ? vecReset(poly[l], poly[l + 1], out) : vecReset(NaN, NaN, out);
 }

--- a/src/polylineFunctions/polylineIntersectRay.ts
+++ b/src/polylineFunctions/polylineIntersectRay.ts
@@ -1,6 +1,6 @@
 import { _polylineIntersectHelper } from "../internal/_polylineIntersectHelper";
 import { segmentIntersectRay } from "../segmentFunctions/segmentIntersectRay";
-import { IPolyline, IRay } from "../types";
+import { Polyline, Ray } from "../types";
 
 /**
  * Computes all locations at which a polyline crosses a given ray.
@@ -24,6 +24,6 @@ import { IPolyline, IRay } from "../types";
  * __see {@link lineIntersectPolyline}
  * __see {@link polylineIntersectSegment}
  */
-export function polylineIntersectRay(poly: IPolyline, ray: IRay) {
+export function polylineIntersectRay(poly: Polyline, ray: Ray) {
   return _polylineIntersectHelper(poly, ray, segmentIntersectRay);
 }

--- a/src/polylineFunctions/polylineIntersectSegment.ts
+++ b/src/polylineFunctions/polylineIntersectSegment.ts
@@ -1,6 +1,6 @@
 import { _polylineIntersectHelper } from "../internal/_polylineIntersectHelper";
 import { segmentIntersectSegment } from "../segmentFunctions/segmentIntersectSegment";
-import { IPolyline, ISegment } from "../types";
+import { Polyline, Segment } from "../types";
 
 /**
  * Computes all locations at which a polyline crosses a given line segment.
@@ -24,6 +24,6 @@ import { IPolyline, ISegment } from "../types";
  * __see {@link segmentIntersectPolyline}
  * __see {@link polylineIntersectRay}
  */
-export function polylineIntersectSegment(poly: IPolyline, segment: ISegment) {
+export function polylineIntersectSegment(poly: Polyline, segment: Segment) {
   return _polylineIntersectHelper(poly, segment, segmentIntersectSegment);
 }

--- a/src/polylineFunctions/polylineIsClosed.ts
+++ b/src/polylineFunctions/polylineIsClosed.ts
@@ -1,5 +1,5 @@
 import { EPSILON_SQ } from "../internal/const";
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 
 /**
  * Returns whether the polyline's last vertex equals its first
@@ -10,7 +10,7 @@ import { IPolyline } from "../types";
  *
  * @param poly
  */
-export function polylineIsClosed(poly: IPolyline) {
+export function polylineIsClosed(poly: Polyline) {
   if (poly.length === 0) {
     return true;
   } else {

--- a/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
+++ b/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
@@ -2,7 +2,7 @@ import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestP
 import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
 import { segmentAlloc } from "../segmentFunctions/segmentAlloc";
 import { segmentNearestDistanceSqToPoint } from "../segmentFunctions/segmentNearestDistanceSqToPoint";
-import { IPolyline, IVec } from "../types";
+import { Polyline, Vec } from "../types";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetSegment } from "./polylineGetSegment";
 
@@ -22,7 +22,7 @@ import { polylineGetSegment } from "./polylineGetSegment";
  * __see {@link IPolyline}
  * __see {@link INearestPointResult}
  */
-export function polylineNearestDistanceSqToPoint(poly: IPolyline, point: IVec, out = nearestPointResultAlloc()) {
+export function polylineNearestDistanceSqToPoint(poly: Polyline, point: Vec, out = nearestPointResultAlloc()) {
   const tmp0 = segmentAlloc();
   const tmp1 = nearestPointResultAlloc();
 

--- a/src/polylineFunctions/polylineTransformBy.ts
+++ b/src/polylineFunctions/polylineTransformBy.ts
@@ -1,4 +1,4 @@
-import { IMat2d, IPolyline } from "../types";
+import { Mat2d, Polyline } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
@@ -18,7 +18,7 @@ import { polylineAlloc } from "./polylineAlloc";
  * __see {@link vecTransformBy}
  * __see {@link Imat2d}
  */
-export function polylineTransformBy(poly: IPolyline, mat: IMat2d, out = polylineAlloc()) {
+export function polylineTransformBy(poly: Polyline, mat: Mat2d, out = polylineAlloc()) {
   const tmp0 = vecAlloc();
   if (out.length !== poly.length) {
     out.length = poly.length;

--- a/src/polylineFunctions/polylineTrim.ts
+++ b/src/polylineFunctions/polylineTrim.ts
@@ -1,5 +1,5 @@
 import { _clamp } from "../internal/_clamp";
-import { IPolyline } from "../types";
+import { Polyline } from "../types";
 import { polylineAlloc } from "./polylineAlloc";
 import { polylineGetNumSegments } from "./polylineGetNumSegments";
 import { polylineGetPointAtT } from "./polylineGetPointAtT";
@@ -27,7 +27,7 @@ import { polylineGetPointAtT } from "./polylineGetPointAtT";
  *  to the allowed domain `[0, poly.length/2 - 1]`.
  * @param out
  */
-export function polylineTrim(poly: IPolyline, tStart: number, tEnd: number, out = polylineAlloc()) {
+export function polylineTrim(poly: Polyline, tStart: number, tEnd: number, out = polylineAlloc()) {
   if (poly.length === 0) {
     out.length = 0;
     return;

--- a/src/rayFunctions/rayAlloc.ts
+++ b/src/rayFunctions/rayAlloc.ts
@@ -1,6 +1,6 @@
-import { IRay } from "../types";
+import { Ray } from "../types";
 
-class Ray implements IRay {
+class _Ray implements Ray {
   public x0 = NaN;
   public y0 = NaN;
   public dirX = NaN;
@@ -28,6 +28,6 @@ class Ray implements IRay {
  *    const result = rayLookAt(existingObj.source, existingObj.target, TMP0);
  *  }
  */
-export function rayAlloc(): IRay {
-  return new Ray();
+export function rayAlloc(): Ray {
+  return new _Ray();
 }

--- a/src/rayFunctions/rayClone.ts
+++ b/src/rayFunctions/rayClone.ts
@@ -1,4 +1,4 @@
-import { IRay } from "../types";
+import { Ray } from "../types";
 import { rayAlloc } from "./rayAlloc";
 import { rayReset } from "./rayReset";
 
@@ -8,6 +8,6 @@ import { rayReset } from "./rayReset";
  * @param ray source ray from which values should be copied
  * @param out
  */
-export function rayClone(ray: IRay, out = rayAlloc()) {
+export function rayClone(ray: Ray, out = rayAlloc()) {
   return rayReset(ray.x0, ray.y0, ray.dirX, ray.dirY, out);
 }

--- a/src/rayFunctions/rayContainsPoint.ts
+++ b/src/rayFunctions/rayContainsPoint.ts
@@ -1,7 +1,7 @@
 import { EPSILON } from "../internal/const";
 import { _dot } from "../internal/_dot";
 import { _dotPerp } from "../internal/_dotPerp";
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 
 /**
  * Determines if the point is on the ray
@@ -15,7 +15,7 @@ import { IRay, IVec } from "../types";
  * __see {@link lineContainsPoint}
  * __see {@link lineWhichSide}
  */
-export function rayContainsPoint(ray: IRay, vec: IVec) {
+export function rayContainsPoint(ray: Ray, vec: Vec) {
   const t = _dot(ray, vec);
   if (t < -EPSILON) {
     return false;

--- a/src/rayFunctions/rayGetPointAtT.ts
+++ b/src/rayFunctions/rayGetPointAtT.ts
@@ -1,4 +1,4 @@
-import { IRay } from "../types";
+import { Ray } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -17,6 +17,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param out
  * __see {@link IRay}
  */
-export function rayGetPointAtT(ray: IRay, t: number, out = vecAlloc()) {
+export function rayGetPointAtT(ray: Ray, t: number, out = vecAlloc()) {
   return vecReset(ray.x0 + ray.dirX * t, ray.y0 + ray.dirY * t, out);
 }

--- a/src/rayFunctions/rayIntersectPolyline.ts
+++ b/src/rayFunctions/rayIntersectPolyline.ts
@@ -1,7 +1,7 @@
 import { _polylineIntersectHelper } from "../internal/_polylineIntersectHelper";
 import { _swapAndReorderIntersections } from "../internal/_swapAndReorderIntersections";
 import { segmentIntersectRay } from "../segmentFunctions/segmentIntersectRay";
-import { IPolyline, IRay } from "../types";
+import { Polyline, Ray } from "../types";
 
 /**
  * Computes all locations at which a ray crosses a given polyline.
@@ -24,6 +24,6 @@ import { IPolyline, IRay } from "../types";
  * __see {@link lineIntersectPolyline}
  * __see {@link polylineIntersectSegment}
  */
-export function rayIntersectPolyline(ray: IRay, poly: IPolyline) {
+export function rayIntersectPolyline(ray: Ray, poly: Polyline) {
   return _swapAndReorderIntersections(_polylineIntersectHelper(poly, ray, segmentIntersectRay));
 }

--- a/src/rayFunctions/rayIntersectRay.ts
+++ b/src/rayFunctions/rayIntersectRay.ts
@@ -5,7 +5,7 @@ import { _rayTransformByOrtho } from "../internal/_rayTransformByOrtho";
 import { mat2dReset } from "../mat2dFunctions/mat2dReset";
 import { intersectionResultAlloc } from "../intersectionResultFunctions/intersectionResultAlloc";
 import { intersectionResultReset } from "../intersectionResultFunctions/intersectionResultReset";
-import { IRay } from "../types";
+import { Ray } from "../types";
 import { rayGetPointAtT } from "./rayGetPointAtT";
 
 /**
@@ -29,7 +29,7 @@ import { rayGetPointAtT } from "./rayGetPointAtT";
  * @param b the second ray to intersect
  * @param out
  */
-export function rayIntersectRay(a: IRay, b: IRay, out = intersectionResultAlloc()) {
+export function rayIntersectRay(a: Ray, b: Ray, out = intersectionResultAlloc()) {
   // Transform ray `b` by the same matrix that maps `a` to the x- basis.
   // We then compute the intersection (with the x-axis) in the transformed space.
   // This transform is equivalent to "translate by (-a.x0, -a.y0) then rotate by -a.angle".

--- a/src/rayFunctions/rayIntersectSegment.ts
+++ b/src/rayFunctions/rayIntersectSegment.ts
@@ -3,7 +3,7 @@ import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
 import { intersectionResultAlloc } from "../intersectionResultFunctions/intersectionResultAlloc";
 import { segmentGetLength } from "../segmentFunctions/segmentGetLength";
-import { IRay, ISegment } from "../types";
+import { Ray, Segment } from "../types";
 import { rayIntersectRay } from "./rayIntersectRay";
 
 /**
@@ -31,7 +31,7 @@ import { rayIntersectRay } from "./rayIntersectRay";
  * @param segment the segment to intersect
  * @param out
  */
-export function rayIntersectSegment(ray: IRay, segment: ISegment, out = intersectionResultAlloc()) {
+export function rayIntersectSegment(ray: Ray, segment: Segment, out = intersectionResultAlloc()) {
   const segmentRay = _lookAt(segment.x0, segment.y0, segment.x1, segment.y1);
   rayIntersectRay(ray, segmentRay, out);
   if (!out.exists) {

--- a/src/rayFunctions/rayLookAt.ts
+++ b/src/rayFunctions/rayLookAt.ts
@@ -1,5 +1,5 @@
 import { _lookAt } from "../internal/_lookAt";
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { rayAlloc } from "./rayAlloc";
 
 /**
@@ -16,6 +16,6 @@ import { rayAlloc } from "./rayAlloc";
  * @param to point that the ray should go through
  * @param out
  */
-export function rayLookAt(from: IVec, to: IVec, out = rayAlloc()) {
+export function rayLookAt(from: Vec, to: Vec, out = rayAlloc()) {
   return _lookAt(from.x, from.y, to.x, to.y, out);
 }

--- a/src/rayFunctions/rayNearestDistanceSqToPoint.ts
+++ b/src/rayFunctions/rayNearestDistanceSqToPoint.ts
@@ -1,7 +1,7 @@
 import { _dot } from "../internal/_dot";
 import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestPointResultAlloc";
 import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 import { vecDistanceSq } from "../vecFunctions/vecDistanceSq";
 import { rayGetPointAtT } from "./rayGetPointAtT";
 
@@ -26,7 +26,7 @@ import { rayGetPointAtT } from "./rayGetPointAtT";
  * __see {@link lineProjectPoint}
  * __see {@link lineNearestDistanceToPoint}
  */
-export function rayNearestDistanceSqToPoint(ray: IRay, point: IVec, out = nearestPointResultAlloc()) {
+export function rayNearestDistanceSqToPoint(ray: Ray, point: Vec, out = nearestPointResultAlloc()) {
   const t = Math.max(0, _dot(ray, point));
   const closest = rayGetPointAtT(ray, t);
   const distanceSq = vecDistanceSq(closest, point);

--- a/src/rayFunctions/rayProjectPoint.ts
+++ b/src/rayFunctions/rayProjectPoint.ts
@@ -1,5 +1,5 @@
 import { _dot } from "../internal/_dot";
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -13,7 +13,7 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param point point to project onto the line
  * @param out
  */
-export function rayProjectPoint(ray: IRay, point: IVec, out = vecAlloc()) {
+export function rayProjectPoint(ray: Ray, point: Vec, out = vecAlloc()) {
   const t = _dot(ray, point);
   return vecReset(ray.x0 + t * ray.dirX, ray.y0 + t * ray.dirY, out);
 }

--- a/src/rayFunctions/rayTransformBy.ts
+++ b/src/rayFunctions/rayTransformBy.ts
@@ -1,5 +1,5 @@
 import { _lookAt } from "../internal/_lookAt";
-import { IMat2d, IRay } from "../types";
+import { Mat2d, Ray } from "../types";
 import { vecReset } from "../vecFunctions/vecReset";
 import { vecTransformBy } from "../vecFunctions/vecTransformBy";
 import { rayAlloc } from "./rayAlloc";
@@ -23,7 +23,7 @@ import { rayAlloc } from "./rayAlloc";
  * __see {@link vecTransformBy}
  * __see {@link Imat2d}
  */
-export function rayTransformBy(ray: IRay, mat: IMat2d, out = rayAlloc()) {
+export function rayTransformBy(ray: Ray, mat: Mat2d, out = rayAlloc()) {
   const p0 = vecReset(ray.x0, ray.y0);
   vecTransformBy(p0, mat, p0);
   const p1 = vecReset(ray.x0 + ray.dirX, ray.y0 + ray.dirY);

--- a/src/rayFunctions/rayWhichSide.ts
+++ b/src/rayFunctions/rayWhichSide.ts
@@ -1,6 +1,6 @@
 import { EPSILON } from "../internal/const";
 import { _dotPerp } from "../internal/_dotPerp";
-import { IRay, IVec } from "../types";
+import { Ray, Vec } from "../types";
 
 /**
  * Computes on which side of the ray (as a _line_) a given point lies.
@@ -27,7 +27,7 @@ import { IRay, IVec } from "../types";
  * __see {@link lineGetClosestDistanceToPoint}
  * __see {@link lineWhichSide}
  */
-export function rayWhichSide(ray: IRay, point: IVec) {
+export function rayWhichSide(ray: Ray, point: Vec) {
   const d = _dotPerp(ray, point);
   return Math.abs(d) < EPSILON ? 0 : Math.sign(d);
 }

--- a/src/segmentFunctions/segmentAlloc.ts
+++ b/src/segmentFunctions/segmentAlloc.ts
@@ -1,6 +1,6 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 
-class Segment implements ISegment {
+class _Segment implements Segment {
   public x0 = NaN;
   public y0 = NaN;
   public x1 = NaN;
@@ -28,6 +28,6 @@ class Segment implements ISegment {
  *    const result = polygonGetSideSegment(existingObj.geometry, 0, TMP0);
  *  }
  */
-export function segmentAlloc(): ISegment {
-  return new Segment();
+export function segmentAlloc(): Segment {
+  return new _Segment();
 }

--- a/src/segmentFunctions/segmentGetEndpoint0.ts
+++ b/src/segmentFunctions/segmentGetEndpoint0.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -8,6 +8,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param segment segment to inspect
  * @param out
  */
-export function segmentGetEndpoint0(segment: ISegment, out = vecAlloc()) {
+export function segmentGetEndpoint0(segment: Segment, out = vecAlloc()) {
   return vecReset(segment.x0, segment.y0, out);
 }

--- a/src/segmentFunctions/segmentGetEndpoint1.ts
+++ b/src/segmentFunctions/segmentGetEndpoint1.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -8,6 +8,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param segment segment to inspect
  * @param out
  */
-export function segmentGetEndpoint1(segment: ISegment, out = vecAlloc()) {
+export function segmentGetEndpoint1(segment: Segment, out = vecAlloc()) {
   return vecReset(segment.x1, segment.y1, out);
 }

--- a/src/segmentFunctions/segmentGetLength.ts
+++ b/src/segmentFunctions/segmentGetLength.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 
 /**
  * Computes the length of the line segment
@@ -9,7 +9,7 @@ import { ISegment } from "../types";
  * __see {@link segmentGetLengthSq}
  * __see {@link vecDistance}
  */
-export function segmentGetLength(segment: ISegment) {
+export function segmentGetLength(segment: Segment) {
   const dx = segment.x1 - segment.x0;
   const dy = segment.y1 - segment.y0;
   return Math.sqrt(dx * dx + dy * dy);

--- a/src/segmentFunctions/segmentGetLengthSq.ts
+++ b/src/segmentFunctions/segmentGetLengthSq.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 
 /**
  * Computes the squared length of the line segment
@@ -9,7 +9,7 @@ import { ISegment } from "../types";
  * __see {@link segmentGetLength}
  * __see {@link vecDistanceSq}
  */
-export function segmentGetLengthSq(segment: ISegment) {
+export function segmentGetLengthSq(segment: Segment) {
   const dx = segment.x1 - segment.x0;
   const dy = segment.y1 - segment.y0;
   return dx * dx + dy * dy;

--- a/src/segmentFunctions/segmentGetPointAtT.ts
+++ b/src/segmentFunctions/segmentGetPointAtT.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 import { vecAlloc } from "../vecFunctions/vecAlloc";
 import { vecReset } from "../vecFunctions/vecReset";
 
@@ -20,6 +20,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * __see {@link ISegment}
  * __see {@link vecLerp}
  */
-export function segmentGetPointAtT(segment: ISegment, t: number, out = vecAlloc()) {
+export function segmentGetPointAtT(segment: Segment, t: number, out = vecAlloc()) {
   return vecReset(segment.x0 * (1 - t) + segment.x1 * t, segment.y0 * (1 - t) + segment.y1 * t, out);
 }

--- a/src/segmentFunctions/segmentIntersectPolyline.ts
+++ b/src/segmentFunctions/segmentIntersectPolyline.ts
@@ -1,6 +1,6 @@
 import { _polylineIntersectHelper } from "../internal/_polylineIntersectHelper";
 import { _swapAndReorderIntersections } from "../internal/_swapAndReorderIntersections";
-import { IPolyline, ISegment } from "../types";
+import { Polyline, Segment } from "../types";
 import { segmentIntersectSegment } from "./segmentIntersectSegment";
 
 /**
@@ -28,6 +28,6 @@ import { segmentIntersectSegment } from "./segmentIntersectSegment";
  * __see {@link segmentIntersectRay}
  * __see {@link segmentIntersectSegment}
  */
-export function segmentIntersectPolyline(segment: ISegment, poly: IPolyline) {
+export function segmentIntersectPolyline(segment: Segment, poly: Polyline) {
   return _swapAndReorderIntersections(_polylineIntersectHelper(poly, segment, segmentIntersectSegment));
 }

--- a/src/segmentFunctions/segmentIntersectRay.ts
+++ b/src/segmentFunctions/segmentIntersectRay.ts
@@ -1,7 +1,7 @@
 import { _intersectionSwapTs } from "../internal/_intersectionSwapTs";
 import { intersectionResultAlloc } from "../intersectionResultFunctions/intersectionResultAlloc";
 import { rayIntersectSegment } from "../rayFunctions/rayIntersectSegment";
-import { IRay, ISegment } from "../types";
+import { Ray, Segment } from "../types";
 
 /**
  * Computes the intersection point between the ray and the segment, if it exists.
@@ -32,6 +32,6 @@ import { IRay, ISegment } from "../types";
  * __see {@link segmentIntersectPolyline}
  * __see {@link segmentIntersectSegment}
  */
-export function segmentIntersectRay(segment: ISegment, ray: IRay, out = intersectionResultAlloc()) {
+export function segmentIntersectRay(segment: Segment, ray: Ray, out = intersectionResultAlloc()) {
   return _intersectionSwapTs(rayIntersectSegment(ray, segment, out));
 }

--- a/src/segmentFunctions/segmentIntersectSegment.ts
+++ b/src/segmentFunctions/segmentIntersectSegment.ts
@@ -3,7 +3,7 @@ import { _intersectionDNE } from "../internal/_intersectionDNE";
 import { _lookAt } from "../internal/_lookAt";
 import { intersectionResultAlloc } from "../intersectionResultFunctions/intersectionResultAlloc";
 import { rayIntersectSegment } from "../rayFunctions/rayIntersectSegment";
-import { ISegment } from "../types";
+import { Segment } from "../types";
 import { segmentGetLength } from "./segmentGetLength";
 
 /**
@@ -33,7 +33,7 @@ import { segmentGetLength } from "./segmentGetLength";
  * __see {@link segmentIntersectPolyline}
  * __see {@link segmentIntersectRay}
  */
-export function segmentIntersectSegment(a: ISegment, b: ISegment, out = intersectionResultAlloc()) {
+export function segmentIntersectSegment(a: Segment, b: Segment, out = intersectionResultAlloc()) {
   const aRay = _lookAt(a.x0, a.y0, a.x1, a.y1);
   rayIntersectSegment(aRay, b, out);
   const segmentLength = segmentGetLength(a);

--- a/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
+++ b/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
@@ -2,7 +2,7 @@ import { _lerp } from "../internal/_lerp";
 import { EPSILON_SQ } from "../internal/const";
 import { nearestPointResultAlloc } from "../nearestPointResultFunctions/nearestPointResultAlloc";
 import { nearestPointResultReset } from "../nearestPointResultFunctions/nearestPointResultReset";
-import { ISegment, IVec } from "../types";
+import { Segment, Vec } from "../types";
 import { vecCross } from "../vecFunctions/vecCross";
 import { vecDot } from "../vecFunctions/vecDot";
 import { vecGetLengthSq } from "../vecFunctions/vecGetLengthSq";
@@ -19,7 +19,7 @@ import { vecReset } from "../vecFunctions/vecReset";
  * __see {@link ISegment}
  * __see {@link INearestPointResult}
  */
-export function segmentNearestDistanceSqToPoint(segment: ISegment, point: IVec, out = nearestPointResultAlloc()) {
+export function segmentNearestDistanceSqToPoint(segment: Segment, point: Vec, out = nearestPointResultAlloc()) {
   const segVector = vecReset(segment.x1 - segment.x0, segment.y1 - segment.y0);
   const pointVector = vecReset(point.x - segment.x0, point.y - segment.y0);
 

--- a/src/segmentFunctions/segmentReverse.ts
+++ b/src/segmentFunctions/segmentReverse.ts
@@ -1,4 +1,4 @@
-import { ISegment } from "../types";
+import { Segment } from "../types";
 import { segmentAlloc } from "./segmentAlloc";
 import { segmentReset } from "./segmentReset";
 
@@ -8,6 +8,6 @@ import { segmentReset } from "./segmentReset";
  * @param segment the segment to reverse
  * @param out
  */
-export function segmentReverse(segment: ISegment, out = segmentAlloc()) {
+export function segmentReverse(segment: Segment, out = segmentAlloc()) {
   return segmentReset(segment.x1, segment.y1, segment.x0, segment.y0, out);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@
  * __see {@link vecAlloc}
  * __see {@link vecReset}
  */
-export interface IVec {
+export interface Vec {
   /** x-coordinate of the vector */
   x: number;
 
@@ -34,7 +34,7 @@ export interface IVec {
  * __see {@link segmentAlloc}
  * __see {@link segmentReset}
  */
-export interface ISegment {
+export interface Segment {
   /**
    * x-coordinate of the starting vertex of the segment.
    */
@@ -66,7 +66,7 @@ export interface ISegment {
  * __see {@link rayAlloc}
  * __see {@link rayReset}
  */
-export interface IRay {
+export interface Ray {
   /**
    * x-coordinate of the ray's initial point
    */
@@ -115,7 +115,7 @@ export interface IRay {
  * __see {@link mat2dAlloc}
  * __see {@link mat2dReset}
  */
-export interface IMat2d {
+export interface Mat2d {
   /**
    * Col 1, row 1 component, usually called `m11` in a 4x4 graphics matrix.
    */
@@ -172,7 +172,7 @@ export interface IMat2d {
  * __see {@link boxAlloc}
  * __see {@link boxReset}
  */
-export interface IBox {
+export interface Box {
   /**
    * Min-X boundary of this box, typically the "left" edge.
    */
@@ -216,7 +216,7 @@ export interface IBox {
  * Math2d chooses to lay out this data in a flattened (interleaved) array, as opposed to e.g. an array of
  * IVecs, for performance and more compact storage.
  */
-export type IPolyline = number[];
+export type Polyline = number[];
 
 /**
  * Data type to hold the result of a point intersection between two pieces of geometry.
@@ -232,7 +232,7 @@ export type IPolyline = number[];
  * __see {@link segmentIntersectRay}
  * __see {@link segmentIntersectSegment}
  */
-export interface IIntersectionResult {
+export interface IntersectionResult {
   /**
    * Whether an intersection was found. If the return value of a function is `false` for the `exists` field,
    * the other Intersection values will be set to `NaN` and should not be interpreted.
@@ -265,7 +265,7 @@ export interface IIntersectionResult {
 /**
  * Data type to hold the result of find the nearest point on a piece of geometry.
  */
-export interface INearestPointResult {
+export interface NearestPointResult {
   /**
    * The x-coordinate of the nearest point.
    */

--- a/src/vecFunctions/vecAdd.ts
+++ b/src/vecFunctions/vecAdd.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -11,6 +11,6 @@ import { vecReset } from "./vecReset";
  * __see {@link vecSubtract}
  * __see {@link vecScale}
  */
-export function vecAdd(a: IVec, b: IVec, out = vecAlloc()) {
+export function vecAdd(a: Vec, b: Vec, out = vecAlloc()) {
   return vecReset(a.x + b.x, a.y + b.y, out);
 }

--- a/src/vecFunctions/vecAlloc.ts
+++ b/src/vecFunctions/vecAlloc.ts
@@ -1,6 +1,6 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
-class Vec implements IVec {
+class Vec implements Vec {
   public x = NaN;
   public y = NaN;
 }
@@ -26,6 +26,6 @@ class Vec implements IVec {
  *    const result = vecNormalize(existingObj.velocity, TMP0);
  *  }
  */
-export function vecAlloc(): IVec {
+export function vecAlloc(): Vec {
   return new Vec();
 }

--- a/src/vecFunctions/vecAlloc.ts
+++ b/src/vecFunctions/vecAlloc.ts
@@ -1,6 +1,6 @@
 import { Vec } from "../types";
 
-class Vec implements Vec {
+class _Vec implements Vec {
   public x = NaN;
   public y = NaN;
 }
@@ -27,5 +27,5 @@ class Vec implements Vec {
  *  }
  */
 export function vecAlloc(): Vec {
-  return new Vec();
+  return new _Vec();
 }

--- a/src/vecFunctions/vecClone.ts
+++ b/src/vecFunctions/vecClone.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -8,6 +8,6 @@ import { vecReset } from "./vecReset";
  * @param vec the vector to copy
  * @param out
  */
-export function vecClone(vec: IVec, out = vecAlloc()) {
+export function vecClone(vec: Vec, out = vecAlloc()) {
   return vecReset(vec.x, vec.y, out);
 }

--- a/src/vecFunctions/vecCross.ts
+++ b/src/vecFunctions/vecCross.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the two-dimensional cross product of the two vectors.
@@ -15,6 +15,6 @@ import { IVec } from "../types";
  * @param v the vector to cross with the first
  * __see {@link vecDot}
  */
-export function vecCross(u: IVec, v: IVec) {
+export function vecCross(u: Vec, v: Vec) {
   return u.x * v.y - u.y * v.x;
 }

--- a/src/vecFunctions/vecDistance.ts
+++ b/src/vecFunctions/vecDistance.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the straight-line (Euclidean) distance between the two points
@@ -8,7 +8,7 @@ import { IVec } from "../types";
  * __see {@link vecDistanceSq}
  * __see {@link vecGetLength}
  */
-export function vecDistance(u: IVec, v: IVec) {
+export function vecDistance(u: Vec, v: Vec) {
   const dx = v.x - u.x;
   const dy = v.y - u.y;
   return Math.sqrt(dx * dx + dy * dy);

--- a/src/vecFunctions/vecDistanceSq.ts
+++ b/src/vecFunctions/vecDistanceSq.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the squared straight-line (i.e. Euclidean) distance between the two points
@@ -8,7 +8,7 @@ import { IVec } from "../types";
  * __see {@link vecDistance}
  * __see {@link vecGetLengthSq}
  */
-export function vecDistanceSq(u: IVec, v: IVec) {
+export function vecDistanceSq(u: Vec, v: Vec) {
   const dx = v.x - u.x;
   const dy = v.y - u.y;
   return dx * dx + dy * dy;

--- a/src/vecFunctions/vecDot.ts
+++ b/src/vecFunctions/vecDot.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the dot product of the two vectors, i.e. `u.x * v.x + u.y * v.y`.
@@ -7,6 +7,6 @@ import { IVec } from "../types";
  * @param v the vector to dot with the first
  * __see {@link vecCross}
  */
-export function vecDot(u: IVec, v: IVec) {
+export function vecDot(u: Vec, v: Vec) {
   return u.x * v.x + u.y * v.y;
 }

--- a/src/vecFunctions/vecGetLength.ts
+++ b/src/vecFunctions/vecGetLength.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the straight-line length (i.e. Euclidean norm) of the given vector.
@@ -7,6 +7,6 @@ import { IVec } from "../types";
  *
  * @param v the vector whose length should be measured
  */
-export function vecGetLength(v: IVec) {
+export function vecGetLength(v: Vec) {
   return Math.sqrt(v.x * v.x + v.y * v.y);
 }

--- a/src/vecFunctions/vecGetLengthSq.ts
+++ b/src/vecFunctions/vecGetLengthSq.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 
 /**
  * Computes the squared straight-line length (i.e. square of the Euclidean norm) of the given vector.
@@ -7,6 +7,6 @@ import { IVec } from "../types";
  *
  * @param v the vector whose squared length should be measured
  */
-export function vecGetLengthSq(v: IVec) {
+export function vecGetLengthSq(v: Vec) {
   return v.x * v.x + v.y * v.y;
 }

--- a/src/vecFunctions/vecLerp.ts
+++ b/src/vecFunctions/vecLerp.ts
@@ -1,5 +1,5 @@
 import { _lerp } from "../internal/_lerp";
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -12,6 +12,6 @@ import { vecReset } from "./vecReset";
  *  the second vector `v`
  * @param out
  */
-export function vecLerp(u: IVec, v: IVec, r: number, out = vecAlloc()) {
+export function vecLerp(u: Vec, v: Vec, r: number, out = vecAlloc()) {
   return vecReset(_lerp(u.x, v.x, r), _lerp(u.y, v.y, r), out);
 }

--- a/src/vecFunctions/vecNormalize.ts
+++ b/src/vecFunctions/vecNormalize.ts
@@ -1,5 +1,5 @@
 import { EPSILON_SQ } from "../internal/const";
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -12,7 +12,7 @@ import { vecReset } from "./vecReset";
  * __see {@link vecGetLength}
  * __see {@link vecGetLengthSq}
  */
-export function vecNormalize(vec: IVec, out = vecAlloc()) {
+export function vecNormalize(vec: Vec, out = vecAlloc()) {
   const lenSq = vec.x * vec.x + vec.y * vec.y;
   if (lenSq < EPSILON_SQ) {
     return vecReset(NaN, NaN, out);

--- a/src/vecFunctions/vecPerp.ts
+++ b/src/vecFunctions/vecPerp.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -9,6 +9,6 @@ import { vecReset } from "./vecReset";
  * @param vec the vector whose perp should be calculated
  * @param out
  */
-export function vecPerp(vec: IVec, out = vecAlloc()) {
+export function vecPerp(vec: Vec, out = vecAlloc()) {
   return vecReset(-vec.y, vec.x, out);
 }

--- a/src/vecFunctions/vecScale.ts
+++ b/src/vecFunctions/vecScale.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -11,6 +11,6 @@ import { vecReset } from "./vecReset";
  * __see {@link vecAdd}
  * __see {@link vecTransformBy}
  */
-export function vecScale(v: IVec, scalar: number, out = vecAlloc()) {
+export function vecScale(v: Vec, scalar: number, out = vecAlloc()) {
   return vecReset(v.x * scalar, v.y * scalar, out);
 }

--- a/src/vecFunctions/vecSubtract.ts
+++ b/src/vecFunctions/vecSubtract.ts
@@ -1,4 +1,4 @@
-import { IVec } from "../types";
+import { Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -12,6 +12,6 @@ import { vecReset } from "./vecReset";
  * __see {@link vecScale}
  * __see {@link vecTransformBy}
  */
-export function vecSubtract(u: IVec, v: IVec, out = vecAlloc()) {
+export function vecSubtract(u: Vec, v: Vec, out = vecAlloc()) {
   return vecReset(u.x - v.x, u.y - v.y, out);
 }

--- a/src/vecFunctions/vecTransformBy.ts
+++ b/src/vecFunctions/vecTransformBy.ts
@@ -1,4 +1,4 @@
-import { IMat2d, IVec } from "../types";
+import { Mat2d, Vec } from "../types";
 import { vecAlloc } from "./vecAlloc";
 import { vecReset } from "./vecReset";
 
@@ -22,6 +22,6 @@ import { vecReset } from "./vecReset";
  * __see {@link Imat2d}
  * __see {@link vecAdd}
  */
-export function vecTransformBy(v: IVec, mat: IMat2d, out = vecAlloc()) {
+export function vecTransformBy(v: Vec, mat: Mat2d, out = vecAlloc()) {
   return vecReset(mat.a * v.x + mat.c * v.y + mat.e, mat.b * v.x + mat.d * v.y + mat.f, out);
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["tslint:latest", "tslint-config-prettier"],
   "rules": {
+    "class-name": false,
     "member-ordering": false,
     "no-implicit-dependencies": [true, "dev"],
     "no-submodule-imports": true


### PR DESCRIPTION
Without jumping into the holy-war at https://github.com/microsoft/TypeScript-Handbook/issues/121, it seems that we're currently more likely to be consistent with other widely-used projects if the primitive interface types _don't_ use the I- prefix.