### PR TITLE
Rename mat2d {e -> tx}, {f -> ty}

### DIFF
--- a/src/__test__/helpers.ts
+++ b/src/__test__/helpers.ts
@@ -52,8 +52,8 @@ export function expectMat2dEqualsApprox(actual: Mat2d, expected: Mat2d) {
   expectEqualsApprox(actual.b, expected.b);
   expectEqualsApprox(actual.c, expected.c);
   expectEqualsApprox(actual.d, expected.d);
-  expectEqualsApprox(actual.e, expected.e);
-  expectEqualsApprox(actual.f, expected.f);
+  expectEqualsApprox(actual.tx, expected.tx);
+  expectEqualsApprox(actual.ty, expected.ty);
 }
 
 export function expectArrayEqualsApprox(actual: number[], expected: number[]) {
@@ -65,8 +65,8 @@ export function expectArrayEqualsApprox(actual: number[], expected: number[]) {
 
 export function _mat2dValues(values: number[]) {
   expect(values).toHaveLength(6);
-  const [a, b, c, d, e, f] = values;
-  return mat2dReset(a, b, c, d, e, f);
+  const [a, b, c, d, tx, ty] = values;
+  return mat2dReset(a, b, c, d, tx, ty);
 }
 
 export function _boxValues(values: number[]) {

--- a/src/__test__/mat2dFunctions/mat2dReset.spec.ts
+++ b/src/__test__/mat2dFunctions/mat2dReset.spec.ts
@@ -8,8 +8,8 @@ describe("mat2dReset", () => {
       b: 4,
       c: 5,
       d: 6,
-      e: 7,
-      f: 8,
+      tx: 7,
+      ty: 8,
     });
   });
 

--- a/src/mat2dFunctions/_mat2d.ts
+++ b/src/mat2dFunctions/_mat2d.ts
@@ -1,12 +1,12 @@
 import { mat2dAlloc } from "./mat2dAlloc";
 
-export function _mat2d(a: number, b: number, c: number, d: number, e: number, f: number) {
+export function _mat2d(a: number, b: number, c: number, d: number, tx: number, ty: number) {
   const out = mat2dAlloc();
   out.a = a;
   out.b = b;
   out.c = c;
   out.d = d;
-  out.tx = e;
-  out.ty = f;
+  out.tx = tx;
+  out.ty = ty;
   return out;
 }

--- a/src/mat2dFunctions/_mat2d.ts
+++ b/src/mat2dFunctions/_mat2d.ts
@@ -6,7 +6,7 @@ export function _mat2d(a: number, b: number, c: number, d: number, e: number, f:
   out.b = b;
   out.c = c;
   out.d = d;
-  out.e = e;
-  out.f = f;
+  out.tx = e;
+  out.ty = f;
   return out;
 }

--- a/src/mat2dFunctions/mat2dAlloc.ts
+++ b/src/mat2dFunctions/mat2dAlloc.ts
@@ -5,8 +5,8 @@ class _Mat2d implements Mat2d {
   public b = NaN;
   public c = NaN;
   public d = NaN;
-  public e = NaN;
-  public f = NaN;
+  public tx = NaN;
+  public ty = NaN;
 }
 
 /**

--- a/src/mat2dFunctions/mat2dClone.ts
+++ b/src/mat2dFunctions/mat2dClone.ts
@@ -9,5 +9,5 @@ import { mat2dReset } from "./mat2dReset";
  * @param out
  */
 export function mat2dClone(mat: Mat2d, out = mat2dAlloc()) {
-  return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.e, mat.f, out);
+  return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.tx, mat.ty, out);
 }

--- a/src/mat2dFunctions/mat2dInvert.ts
+++ b/src/mat2dFunctions/mat2dInvert.ts
@@ -20,8 +20,8 @@ export function mat2dInvert(mat: Mat2d, out = mat2dAlloc()) {
       -detInverse * mat.b,
       -detInverse * mat.c,
       detInverse * mat.a,
-      detInverse * (mat.c * mat.f - mat.d * mat.e),
-      detInverse * (mat.b * mat.e - mat.a * mat.f),
+      detInverse * (mat.c * mat.ty - mat.d * mat.tx),
+      detInverse * (mat.b * mat.tx - mat.a * mat.ty),
       out,
     );
   }

--- a/src/mat2dFunctions/mat2dMulMat2d.ts
+++ b/src/mat2dFunctions/mat2dMulMat2d.ts
@@ -11,9 +11,9 @@ import { mat2dReset } from "./mat2dReset";
  * Affine matrix multiplication is defined by
  *
  * ```
- * ⎡m1.a m1.c m1.e⎤ ⎡m2.a m2.c m2.e⎤   ⎡r.a r.c r.e⎤
- * ⎢m1.b m1.d m1.f⎥ ⎢m2.b m2.d m2.f⎥ = ⎢r.b r.d r.f⎥
- * ⎣   0    0    1⎦ ⎣   0    0    1⎦   ⎣  0   0   1⎦
+ * ⎡m1.a m1.c m1.tx⎤ ⎡m2.a m2.c m2.tx⎤   ⎡r.a r.c r.tx⎤
+ * ⎢m1.b m1.d m1.ty⎥ ⎢m2.b m2.d m2.ty⎥ = ⎢r.b r.d r.ty⎥
+ * ⎣   0    0     1⎦ ⎣   0    0     1⎦   ⎣  0   0    1⎦
  * ```
  *
  * where:
@@ -21,8 +21,8 @@ import { mat2dReset } from "./mat2dReset";
  *  - `r.b = m1.b * m2.a + m1.d * m2.b`
  *  - `r.c = m1.a * m2.c + m1.c * m2.d`
  *  - `r.d = m1.b * m2.c + m1.d * m2.d`
- *  - `r.e = m1.a * m2.e + m1.c * m2.f + m1.e`
- *  - `r.f = m1.b * m2.e + m1.c * m2.f + m1.f`
+ *  - `r.tx = m1.a * m2.tx + m1.c * m2.ty + m1.tx`
+ *  - `r.ty = m1.b * m2.e + m1.c * m2.ty + m1.ty`
  *
  * @param m1 the first matrix to multiply
  * @param m2 the second matrix to multiply
@@ -35,7 +35,7 @@ export function mat2dMulMat2d(m1: Mat2d, m2: Mat2d, out = mat2dAlloc()) {
   const b = m1.b * m2.a + m1.d * m2.b;
   const c = m1.a * m2.c + m1.c * m2.d;
   const d = m1.b * m2.c + m1.d * m2.d;
-  const e = m1.a * m2.e + m1.c * m2.f + m1.e;
-  const f = m1.b * m2.e + m1.c * m2.f + m1.f;
-  return mat2dReset(a, b, c, d, e, f, out);
+  const tx = m1.a * m2.tx + m1.c * m2.ty + m1.tx;
+  const ty = m1.b * m2.tx + m1.c * m2.ty + m1.ty;
+  return mat2dReset(a, b, c, d, tx, ty, out);
 }

--- a/src/mat2dFunctions/mat2dReset.ts
+++ b/src/mat2dFunctions/mat2dReset.ts
@@ -26,7 +26,7 @@ export function mat2dReset(a: number, b: number, c: number, d: number, e: number
   out.b = b;
   out.c = c;
   out.d = d;
-  out.e = e;
-  out.f = f;
+  out.tx = e;
+  out.ty = f;
   return out;
 }

--- a/src/mat2dFunctions/mat2dReset.ts
+++ b/src/mat2dFunctions/mat2dReset.ts
@@ -6,27 +6,27 @@ import { mat2dAlloc } from "./mat2dAlloc";
  * The resulting matrix will have the shape
  *
  * ```
- * ⎡a c e⎤
- * ⎣b d f⎦
+ * ⎡a c tx⎤
+ * ⎣b d ty⎦
  * ```
  *
  * @param a col 1, row 1 component, usually called `m11` in a 4x4 graphics matrix
  * @param b col 1, row 2 component, usually called `m12` in a 4x4 graphics matrix
  * @param c col 2, row 1 component, usually called `m21` in a 4x4 graphics matrix
  * @param d col 2, row 2 component, usually called `m22` in a 4x4 graphics matrix
- * @param e col 3, row 1 component, usually called `tx` or `m41` in a 4x4 graphics matrix
- * @param f col 3, row 2 component, usually called `ty` or `m42` in a 4x4 graphics matrix
+ * @param tx col 3, row 1 component, usually called `m41` in a 4x4 graphics matrix
+ * @param ty col 3, row 2 component, usually called `m42` in a 4x4 graphics matrix
  * @param out
  * __see {@link Imat2d}
  * __see {@link mat2dAlloc}
  * __see {@link mat2dClone}
  */
-export function mat2dReset(a: number, b: number, c: number, d: number, e: number, f: number, out = mat2dAlloc()) {
+export function mat2dReset(a: number, b: number, c: number, d: number, tx: number, ty: number, out = mat2dAlloc()) {
   out.a = a;
   out.b = b;
   out.c = c;
   out.d = d;
-  out.tx = e;
-  out.ty = f;
+  out.tx = tx;
+  out.ty = ty;
   return out;
 }

--- a/src/mat2dFunctions/mat2dRotate.ts
+++ b/src/mat2dFunctions/mat2dRotate.ts
@@ -27,8 +27,8 @@ export function mat2dRotate(mat: Mat2d, theta: number, out = mat2dAlloc()) {
     cos * mat.b - sin * mat.d,
     sin * mat.a + cos * mat.c,
     sin * mat.b + cos * mat.d,
-    mat.e,
-    mat.f,
+    mat.tx,
+    mat.ty,
     out,
   );
 }

--- a/src/mat2dFunctions/mat2dScale.ts
+++ b/src/mat2dFunctions/mat2dScale.ts
@@ -17,5 +17,5 @@ import { mat2dReset } from "./mat2dReset";
  * __see {@link mat2dMulMat2d}
  */
 export function mat2dScale(mat: Mat2d, scale: number, out = mat2dAlloc()) {
-  return mat2dReset(scale * mat.a, scale * mat.b, scale * mat.c, scale * mat.d, scale * mat.e, scale * mat.f, out);
+  return mat2dReset(scale * mat.a, scale * mat.b, scale * mat.c, scale * mat.d, scale * mat.tx, scale * mat.ty, out);
 }

--- a/src/mat2dFunctions/mat2dTranslate.ts
+++ b/src/mat2dFunctions/mat2dTranslate.ts
@@ -17,5 +17,5 @@ import { mat2dReset } from "./mat2dReset";
  * __see {@link mat2dMulMat2d}
  */
 export function mat2dTranslate(mat: Mat2d, tx: number, ty: number, out = mat2dAlloc()) {
-  return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.e + tx, mat.f + ty, out);
+  return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.tx + tx, mat.ty + ty, out);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,19 +97,19 @@ export interface Ray {
  * i.e. a linear 2x2 matrix plus a 2D translation. Math2d chooses to lay out this data in a
  * flat object structure, as opposed to an array or nested arrays, for ease of use and performance.
  * The field names used here match other standards, like the native DOMMatrix
- * specification and the Canvas reference APIs.
+ * specification, the Canvas reference APIs, and the open-source glMatrix library.
  *
  * ```
- * ⎡a c e⎤
- * ⎣b d f⎦
+ * ⎡a c tx⎤
+ * ⎣b d ty⎦
  * ```
  *
  * Per usual linear algebra, multiplying a vector `v = (x, y)` according to this affine matrix is defined by:
  *
  * ```
- * ⎡a c e⎤ ⎛x⎞   ⎛ax + cy + e⎞
- * ⎢b d f⎥ ⎜y⎟ = ⎜bx + dy + f⎟
- * ⎣0 0 1⎦ ⎝1⎠   ⎝     1     ⎠
+ * ⎡a c e⎤ ⎛x⎞   ⎛ax + cy + tx⎞
+ * ⎢b d f⎥ ⎜y⎟ = ⎜bx + dy + ty⎟
+ * ⎣0 0 1⎦ ⎝1⎠   ⎝      1     ⎠
  * ```
  *
  * __see {@link mat2dAlloc}
@@ -137,14 +137,14 @@ export interface Mat2d {
   d: number;
 
   /**
-   * Col 3, row 1 component, usually called `tx` or `m41` in a 4x4 graphics matrix.
+   * Col 3, row 1 component, usually called `m41` in a 4x4 graphics matrix.
    */
-  e: number;
+  tx: number;
 
   /**
-   * Col 3, row 2 component, usually called `ty` or `m42` in a 4x4 graphics matrix.
+   * Col 3, row 2 component, usually called `m42` in a 4x4 graphics matrix.
    */
-  f: number;
+  ty: number;
 }
 
 /**

--- a/src/vecFunctions/vecTransformBy.ts
+++ b/src/vecFunctions/vecTransformBy.ts
@@ -11,9 +11,9 @@ import { vecReset } from "./vecReset";
  * `[a b c d e f]` is defined by:
  *
  * ```
- * ⎡a c e⎤ ⎛x⎞   ⎛ax + cy + e⎞
- * ⎢b d f⎥ ⎜y⎟ = ⎜bx + dy + f⎟
- * ⎣0 0 1⎦ ⎝1⎠   ⎝     1     ⎠
+ * ⎡a c tx⎤ ⎛x⎞   ⎛ax + cy + tx⎞
+ * ⎢b d ty⎥ ⎜y⎟ = ⎜bx + dy + ty⎟
+ * ⎣0 0  1⎦ ⎝1⎠   ⎝      1     ⎠
  * ```
  *
  * @param v the vector to transform
@@ -23,5 +23,5 @@ import { vecReset } from "./vecReset";
  * __see {@link vecAdd}
  */
 export function vecTransformBy(v: Vec, mat: Mat2d, out = vecAlloc()) {
-  return vecReset(mat.a * v.x + mat.c * v.y + mat.e, mat.b * v.x + mat.d * v.y + mat.f, out);
+  return vecReset(mat.a * v.x + mat.c * v.y + mat.tx, mat.b * v.x + mat.d * v.y + mat.ty, out);
 }


### PR DESCRIPTION
This change is largely to align with the other great open source `glMatrix` library. While e.g. the open standards for SVGMatrix (https://developer.mozilla.org/en-US/docs/Web/API/SVGMatrix) et al. use `{a, b, c, d, e, f}`, ultimately the `{a, b, c, d, tx, ty}` should be slightly easier to grok and document.