### PR TITLE
Remove all '@see' references from jsdoc

### DIFF
--- a/src/boxFunctions/boxGetOutCode.ts
+++ b/src/boxFunctions/boxGetOutCode.ts
@@ -16,10 +16,6 @@ import { Box, Vec } from "../types";
  *  const myBox = boxReset(-2, -2, 2, 2);
  *  const outCode1 = boxGetOutCode(myBox, vecReset(-4, 4)); // returns Out.MIN_X | Out.MAX_Y
  *  const outCode2 = boxGetOutCode(myBox, vec2Origin()); // returns 0
- * __see Out.MIN_X
- * __see Out.MAX_X
- * __see Out.MIN_Y
- * __see Out.MAX_Y
  */
 export function boxGetOutCode(box: Box, point: Vec) {
   let out = 0;

--- a/src/boxFunctions/boxIntersection.ts
+++ b/src/boxFunctions/boxIntersection.ts
@@ -15,7 +15,6 @@ import { boxReset } from "./boxReset";
  * @param a first box to compute intersection for
  * @param b second box to compute intersection for
  * @param out
- * __see {@link boxUnion}
  */
 export function boxIntersection(a: Box, b: Box, out = boxAlloc()) {
   return boxReset(

--- a/src/mat2dFunctions/mat2dFromRotation.ts
+++ b/src/mat2dFunctions/mat2dFromRotation.ts
@@ -11,9 +11,6 @@ import { mat2dReset } from "./mat2dReset";
  *
  * @param theta angle in radians to create rotation for
  * @param out
- * __see {@link mat2dFromTranslation}
- * __see {@link mat2dRotate}
- * __see {@link mat2dReset}
  */
 export function mat2dFromRotation(theta: number, out = mat2dAlloc()) {
   const sin = Math.sin(theta);

--- a/src/mat2dFunctions/mat2dFromTranslation.ts
+++ b/src/mat2dFunctions/mat2dFromTranslation.ts
@@ -6,9 +6,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param tx the x translation component
  * @param ty the y translation component
  * @param out
- * __see {@link mat2dFromRotation}
- * __see {@link mat2dTranslate}
- * __see {@link mat2dReset}
  */
 export function mat2dFromTranslation(tx: number, ty: number, out = mat2dAlloc()) {
   return mat2dReset(1, 0, 0, 1, tx, ty, out);

--- a/src/mat2dFunctions/mat2dIsOrthogonal.ts
+++ b/src/mat2dFunctions/mat2dIsOrthogonal.ts
@@ -11,7 +11,6 @@ import { Mat2d } from "../types";
  * so in particular it preserves normals.
  *
  * @param mat the matrix to check for orthogonality
- * __see {@link mat2dIsTranslationOnly}
  */
 export function mat2dIsOrthogonal(mat: Mat2d) {
   const d1Sq = mat.a * mat.a + mat.b * mat.b;

--- a/src/mat2dFunctions/mat2dIsTranslationOnly.ts
+++ b/src/mat2dFunctions/mat2dIsTranslationOnly.ts
@@ -11,7 +11,6 @@ import { Mat2d } from "../types";
  * ```
  *
  * @param mat the matrix to inspect
- * __see {@link mat2dIsOrthogonal}
  */
 export function mat2dIsTranslationOnly(mat: Mat2d) {
   return mat.a === 1 && mat.b === 0 && mat.c === 0 && mat.d === 1;

--- a/src/mat2dFunctions/mat2dMulMat2d.ts
+++ b/src/mat2dFunctions/mat2dMulMat2d.ts
@@ -27,8 +27,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param m1 the first matrix to multiply
  * @param m2 the second matrix to multiply
  * @param out
- * __see {@link IMatrix}
- * __see {@link vecTransformBy}
  */
 export function mat2dMulMat2d(m1: Mat2d, m2: Mat2d, out = mat2dAlloc()) {
   const a = m1.a * m2.a + m1.c * m2.b;

--- a/src/mat2dFunctions/mat2dReset.ts
+++ b/src/mat2dFunctions/mat2dReset.ts
@@ -17,9 +17,6 @@ import { mat2dAlloc } from "./mat2dAlloc";
  * @param tx col 3, row 1 component, usually called `m41` in a 4x4 graphics matrix
  * @param ty col 3, row 2 component, usually called `m42` in a 4x4 graphics matrix
  * @param out
- * __see {@link Imat2d}
- * __see {@link mat2dAlloc}
- * __see {@link mat2dClone}
  */
 export function mat2dReset(a: number, b: number, c: number, d: number, tx: number, ty: number, out = mat2dAlloc()) {
   out.a = a;

--- a/src/mat2dFunctions/mat2dRotate.ts
+++ b/src/mat2dFunctions/mat2dRotate.ts
@@ -16,8 +16,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param mat the matrix to transform
  * @param theta rotation angle in radians to apply on top of the given matrix
  * @param out
- * __see {@link mat2dFromRotation}
- * __see {@link mat2dMulMat2d}
  */
 export function mat2dRotate(mat: Mat2d, theta: number, out = mat2dAlloc()) {
   const cos = Math.cos(theta);

--- a/src/mat2dFunctions/mat2dScale.ts
+++ b/src/mat2dFunctions/mat2dScale.ts
@@ -14,7 +14,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param mat the matrix to transform
  * @param theta rotation angle in radians to apply on top of the given matrix
  * @param out
- * __see {@link mat2dMulMat2d}
  */
 export function mat2dScale(mat: Mat2d, scale: number, out = mat2dAlloc()) {
   return mat2dReset(scale * mat.a, scale * mat.b, scale * mat.c, scale * mat.d, scale * mat.tx, scale * mat.ty, out);

--- a/src/mat2dFunctions/mat2dTranslate.ts
+++ b/src/mat2dFunctions/mat2dTranslate.ts
@@ -13,8 +13,6 @@ import { mat2dReset } from "./mat2dReset";
  * @param tx x-component of the translation to apply
  * @param ty y-component of the translation to apply
  * @param out
- * __see {@link mat2dFromTranslation}
- * __see {@link mat2dMulMat2d}
  */
 export function mat2dTranslate(mat: Mat2d, tx: number, ty: number, out = mat2dAlloc()) {
   return mat2dReset(mat.a, mat.b, mat.c, mat.d, mat.tx + tx, mat.ty + ty, out);

--- a/src/polylineFunctions/polylineGetDistanceAtT.ts
+++ b/src/polylineFunctions/polylineGetDistanceAtT.ts
@@ -14,8 +14,6 @@ import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
  *
  * @param poly the polyline to inspect
  * @param t the parametric value along the polyline's geometry to measure distance to
- * __see {@link IPolyline}
- * __see {@link polylineGetTAtDistance}
  */
 export function polylineGetDistanceAtT(polyline: Polyline, t: number) {
   const numSegments = polylineGetNumSegments(polyline);

--- a/src/polylineFunctions/polylineGetPointAtT.ts
+++ b/src/polylineFunctions/polylineGetPointAtT.ts
@@ -11,7 +11,6 @@ import { polylineGetNumSegments } from "./polylineGetNumSegments";
  * @param poly the polyline to compute a point on
  * @param t the parameter variable at which a point should be calculated
  * @param out
- * __see {@link IPolyline}
  */
 export function polylineGetPointAtT(poly: Polyline, t: number, out = vecAlloc()) {
   const maxT = polylineGetNumSegments(poly);

--- a/src/polylineFunctions/polylineGetTAtDistance.ts
+++ b/src/polylineFunctions/polylineGetTAtDistance.ts
@@ -11,8 +11,6 @@ import { polylineGetSegmentLength } from "./polylineGetSegmentLength";
  *
  * @param poly the polyline to inspect
  * @param d distance along the polyline to travel
- * __see {@link IPolyline}
- * __see {@link polylineGetDistanceAtT}
  */
 export function polylineGetTAtDistance(poly: Polyline, d: number) {
   if (d < 0) {

--- a/src/polylineFunctions/polylineIntersectRay.ts
+++ b/src/polylineFunctions/polylineIntersectRay.ts
@@ -19,10 +19,6 @@ import { Polyline, Ray } from "../types";
  *
  * @param poly
  * @param ray
- * __see {@link IIntersectionResult}
- * __see {@link IPolyline}
- * __see {@link lineIntersectPolyline}
- * __see {@link polylineIntersectSegment}
  */
 export function polylineIntersectRay(poly: Polyline, ray: Ray) {
   return _polylineIntersectHelper(poly, ray, segmentIntersectRay);

--- a/src/polylineFunctions/polylineIntersectSegment.ts
+++ b/src/polylineFunctions/polylineIntersectSegment.ts
@@ -19,10 +19,6 @@ import { Polyline, Segment } from "../types";
  *
  * @param poly
  * @param segment
- * __see {@link IIntersectionResult}
- * __see {@link IPolyline}
- * __see {@link segmentIntersectPolyline}
- * __see {@link polylineIntersectRay}
  */
 export function polylineIntersectSegment(poly: Polyline, segment: Segment) {
   return _polylineIntersectHelper(poly, segment, segmentIntersectSegment);

--- a/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
+++ b/src/polylineFunctions/polylineNearestDistanceSqToPoint.ts
@@ -19,8 +19,6 @@ import { polylineGetSegment } from "./polylineGetSegment";
  * @param poly the polyline to inspect
  * @param point the point to measure distance to
  * @param out
- * __see {@link IPolyline}
- * __see {@link INearestPointResult}
  */
 export function polylineNearestDistanceSqToPoint(poly: Polyline, point: Vec, out = nearestPointResultAlloc()) {
   const tmp0 = segmentAlloc();

--- a/src/polylineFunctions/polylineTransformBy.ts
+++ b/src/polylineFunctions/polylineTransformBy.ts
@@ -15,8 +15,6 @@ import { polylineAlloc } from "./polylineAlloc";
  * @param poly polyline to transform
  * @param mat affine transform to apply
  * @param out
- * __see {@link vecTransformBy}
- * __see {@link Imat2d}
  */
 export function polylineTransformBy(poly: Polyline, mat: Mat2d, out = polylineAlloc()) {
   const tmp0 = vecAlloc();

--- a/src/rayFunctions/rayContainsPoint.ts
+++ b/src/rayFunctions/rayContainsPoint.ts
@@ -12,8 +12,6 @@ import { Ray, Vec } from "../types";
  *
  * @param ray the ray to inspect
  * @param vec point to be checked
- * __see {@link lineContainsPoint}
- * __see {@link lineWhichSide}
  */
 export function rayContainsPoint(ray: Ray, vec: Vec) {
   const t = _dot(ray, vec);

--- a/src/rayFunctions/rayGetPointAtT.ts
+++ b/src/rayFunctions/rayGetPointAtT.ts
@@ -15,7 +15,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param ray the ray to inspect
  * @param t distance along the ray at which to compute point
  * @param out
- * __see {@link IRay}
  */
 export function rayGetPointAtT(ray: Ray, t: number, out = vecAlloc()) {
   return vecReset(ray.x0 + ray.dirX * t, ray.y0 + ray.dirY * t, out);

--- a/src/rayFunctions/rayIntersectPolyline.ts
+++ b/src/rayFunctions/rayIntersectPolyline.ts
@@ -19,10 +19,6 @@ import { Polyline, Ray } from "../types";
  *
  * @param poly
  * @param ray
- * __see {@link IIntersectionResult}
- * __see {@link IPolyline}
- * __see {@link lineIntersectPolyline}
- * __see {@link polylineIntersectSegment}
  */
 export function rayIntersectPolyline(ray: Ray, poly: Polyline) {
   return _swapAndReorderIntersections(_polylineIntersectHelper(poly, ray, segmentIntersectRay));

--- a/src/rayFunctions/rayNearestDistanceSqToPoint.ts
+++ b/src/rayFunctions/rayNearestDistanceSqToPoint.ts
@@ -23,8 +23,6 @@ import { rayGetPointAtT } from "./rayGetPointAtT";
  * @param ray the ray to inspect
  * @param point the reference point to project onto the ray
  * @param out
- * __see {@link lineProjectPoint}
- * __see {@link lineNearestDistanceToPoint}
  */
 export function rayNearestDistanceSqToPoint(ray: Ray, point: Vec, out = nearestPointResultAlloc()) {
   const t = Math.max(0, _dot(ray, point));

--- a/src/rayFunctions/rayReset.ts
+++ b/src/rayFunctions/rayReset.ts
@@ -13,9 +13,6 @@ import { rayAlloc } from "./rayAlloc";
  * @param dirY y-coordinate of the ray's direction vector, which should form a unit vector
  *  along with the provided `dirX`
  * @param out
- * __see {@link IRay}
- * __see {@link rayAlloc}
- * __see {@link rayClone}
  */
 export function rayReset(x0: number, y0: number, dirX: number, dirY: number, out = rayAlloc()) {
   out.x0 = x0;

--- a/src/rayFunctions/rayTransformBy.ts
+++ b/src/rayFunctions/rayTransformBy.ts
@@ -20,8 +20,6 @@ import { rayAlloc } from "./rayAlloc";
  * @param ray the ray to transform
  * @param mat the affine transform to apply
  * @param out
- * __see {@link vecTransformBy}
- * __see {@link Imat2d}
  */
 export function rayTransformBy(ray: Ray, mat: Mat2d, out = rayAlloc()) {
   const p0 = vecReset(ray.x0, ray.y0);

--- a/src/rayFunctions/rayWhichSide.ts
+++ b/src/rayFunctions/rayWhichSide.ts
@@ -24,8 +24,6 @@ import { Ray, Vec } from "../types";
  *
  * @param ray the line to inspect
  * @param point the reference point to check for closest distance
- * __see {@link lineGetClosestDistanceToPoint}
- * __see {@link lineWhichSide}
  */
 export function rayWhichSide(ray: Ray, point: Vec) {
   const d = _dotPerp(ray, point);

--- a/src/segmentFunctions/segmentGetLength.ts
+++ b/src/segmentFunctions/segmentGetLength.ts
@@ -6,8 +6,6 @@ import { Segment } from "../types";
  * This is simply `√((x1 - x0)² + (y1 - y0)²)`.
  *
  * @param segment segment to measure
- * __see {@link segmentGetLengthSq}
- * __see {@link vecDistance}
  */
 export function segmentGetLength(segment: Segment) {
   const dx = segment.x1 - segment.x0;

--- a/src/segmentFunctions/segmentGetLengthSq.ts
+++ b/src/segmentFunctions/segmentGetLengthSq.ts
@@ -6,8 +6,6 @@ import { Segment } from "../types";
  * This is simply `(x1 - x0)² + (y1 - y0)²`.
  *
  * @param segment segment to measure
- * __see {@link segmentGetLength}
- * __see {@link vecDistanceSq}
  */
 export function segmentGetLengthSq(segment: Segment) {
   const dx = segment.x1 - segment.x0;

--- a/src/segmentFunctions/segmentGetPointAtT.ts
+++ b/src/segmentFunctions/segmentGetPointAtT.ts
@@ -17,8 +17,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param segment the segment to inspect
  * @param t linear ratio along the segment to return
  * @param out
- * __see {@link ISegment}
- * __see {@link vecLerp}
  */
 export function segmentGetPointAtT(segment: Segment, t: number, out = vecAlloc()) {
   return vecReset(segment.x0 * (1 - t) + segment.x1 * t, segment.y0 * (1 - t) + segment.y1 * t, out);

--- a/src/segmentFunctions/segmentIntersectPolyline.ts
+++ b/src/segmentFunctions/segmentIntersectPolyline.ts
@@ -22,11 +22,6 @@ import { segmentIntersectSegment } from "./segmentIntersectSegment";
  *
  * @param segment the segment to intersect
  * @param poly the polyline to find intersections with
- * __see {@link IIntersectionResult}
- * __see {@link ISegment}
- * __see {@link polylineIntersectSegment}
- * __see {@link segmentIntersectRay}
- * __see {@link segmentIntersectSegment}
  */
 export function segmentIntersectPolyline(segment: Segment, poly: Polyline) {
   return _swapAndReorderIntersections(_polylineIntersectHelper(poly, segment, segmentIntersectSegment));

--- a/src/segmentFunctions/segmentIntersectRay.ts
+++ b/src/segmentFunctions/segmentIntersectRay.ts
@@ -27,10 +27,6 @@ import { Ray, Segment } from "../types";
  * @param segment the segment to intersect
  * @param ray the ray to find intersection with
  * @param out
- * __see {@link IIntersectionResult}
- * __see {@link ISegment}
- * __see {@link segmentIntersectPolyline}
- * __see {@link segmentIntersectSegment}
  */
 export function segmentIntersectRay(segment: Segment, ray: Ray, out = intersectionResultAlloc()) {
   return _intersectionSwapTs(rayIntersectSegment(ray, segment, out));

--- a/src/segmentFunctions/segmentIntersectSegment.ts
+++ b/src/segmentFunctions/segmentIntersectSegment.ts
@@ -28,10 +28,6 @@ import { segmentGetLength } from "./segmentGetLength";
  * @param a the first segment to intersect
  * @param b the second segment to find intersections with
  * @param out
- * __see {@link IIntersectionResult}
- * __see {@link ISegment}
- * __see {@link segmentIntersectPolyline}
- * __see {@link segmentIntersectRay}
  */
 export function segmentIntersectSegment(a: Segment, b: Segment, out = intersectionResultAlloc()) {
   const aRay = _lookAt(a.x0, a.y0, a.x1, a.y1);

--- a/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
+++ b/src/segmentFunctions/segmentNearestDistanceSqToPoint.ts
@@ -16,8 +16,6 @@ import { vecReset } from "../vecFunctions/vecReset";
  * @param segment segment to inspect
  * @param point point to measure squared distance to
  * @param out
- * __see {@link ISegment}
- * __see {@link INearestPointResult}
  */
 export function segmentNearestDistanceSqToPoint(segment: Segment, point: Vec, out = nearestPointResultAlloc()) {
   const segVector = vecReset(segment.x1 - segment.x0, segment.y1 - segment.y0);

--- a/src/segmentFunctions/segmentReset.ts
+++ b/src/segmentFunctions/segmentReset.ts
@@ -9,9 +9,6 @@ import { segmentAlloc } from "./segmentAlloc";
  * @param x1 x-coordinate of the segment's ending vertex
  * @param y1 y-coordinate of the segment's ending vertex
  * @param out
- * __see {@link ISegment}
- * __see {@link segmentAlloc}
- * __see {@link segmentClone}
  */
 export function segmentReset(x0: number, y0: number, x1: number, y1: number, out = segmentAlloc()) {
   out.x0 = x0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,8 +8,6 @@
  * for ease of use. After carefully benchmarking that difference, it's been confirmed that this
  * does not sacrifice performance or memory compactness.
  *
- * __see {@link vecAlloc}
- * __see {@link vecReset}
  */
 export interface Vec {
   /** x-coordinate of the vector */
@@ -31,8 +29,6 @@ export interface Vec {
  * between its endpoints, where _t_ = 0 represents its starting vertex and _t_ = 1 its
  * ending vertex.
  *
- * __see {@link segmentAlloc}
- * __see {@link segmentReset}
  */
 export interface Segment {
   /**
@@ -63,8 +59,6 @@ export interface Segment {
  * Where relevant, a ray is parameterized according to _t_ ≥ 0 with movement of distance _t_ along its direction vector.
  * In this mapping, _t_ = 0 represents the initial point (x0, y0).
  *
- * __see {@link rayAlloc}
- * __see {@link rayReset}
  */
 export interface Ray {
   /**
@@ -112,8 +106,6 @@ export interface Ray {
  * ⎣0 0 1⎦ ⎝1⎠   ⎝      1     ⎠
  * ```
  *
- * __see {@link mat2dAlloc}
- * __see {@link mat2dReset}
  */
 export interface Mat2d {
   /**
@@ -169,8 +161,6 @@ export interface Mat2d {
  * Math2d chooses to lay out this data in a
  * flat object structure, as opposed to an array or nested arrays, for ease of use and performance.
  *
- * __see {@link boxAlloc}
- * __see {@link boxReset}
  */
 export interface Box {
   /**
@@ -221,16 +211,6 @@ export type Polyline = number[];
 /**
  * Data type to hold the result of a point intersection between two pieces of geometry.
  *
- * __see {@link polygonIntersectRay}
- * __see {@link polygonIntersectSegment}
- * __see {@link polylineIntersectRay}
- * __see {@link polylineIntersectSegment}
- * __see {@link rayIntersectPolyline}
- * __see {@link rayIntersectRay}
- * __see {@link rayIntersectSegment}
- * __see {@link segmentIntersectPolyline}
- * __see {@link segmentIntersectRay}
- * __see {@link segmentIntersectSegment}
  */
 export interface IntersectionResult {
   /**

--- a/src/vecFunctions/vecAdd.ts
+++ b/src/vecFunctions/vecAdd.ts
@@ -8,8 +8,6 @@ import { vecReset } from "./vecReset";
  * @param a
  * @param b
  * @param out
- * __see {@link vecSubtract}
- * __see {@link vecScale}
  */
 export function vecAdd(a: Vec, b: Vec, out = vecAlloc()) {
   return vecReset(a.x + b.x, a.y + b.y, out);

--- a/src/vecFunctions/vecCross.ts
+++ b/src/vecFunctions/vecCross.ts
@@ -13,7 +13,6 @@ import { Vec } from "../types";
  *
  * @param u the first vector
  * @param v the vector to cross with the first
- * __see {@link vecDot}
  */
 export function vecCross(u: Vec, v: Vec) {
   return u.x * v.y - u.y * v.x;

--- a/src/vecFunctions/vecDistance.ts
+++ b/src/vecFunctions/vecDistance.ts
@@ -5,8 +5,6 @@ import { Vec } from "../types";
  *
  * @param u the first point
  * @param v the second point, to which distance should be measured from the first
- * __see {@link vecDistanceSq}
- * __see {@link vecGetLength}
  */
 export function vecDistance(u: Vec, v: Vec) {
   const dx = v.x - u.x;

--- a/src/vecFunctions/vecDistanceSq.ts
+++ b/src/vecFunctions/vecDistanceSq.ts
@@ -5,8 +5,6 @@ import { Vec } from "../types";
  *
  * @param u the first point
  * @param v the second point to which squared distance should be measured
- * __see {@link vecDistance}
- * __see {@link vecGetLengthSq}
  */
 export function vecDistanceSq(u: Vec, v: Vec) {
   const dx = v.x - u.x;

--- a/src/vecFunctions/vecDot.ts
+++ b/src/vecFunctions/vecDot.ts
@@ -5,7 +5,6 @@ import { Vec } from "../types";
  *
  * @param u the first vector
  * @param v the vector to dot with the first
- * __see {@link vecCross}
  */
 export function vecDot(u: Vec, v: Vec) {
   return u.x * v.x + u.y * v.y;

--- a/src/vecFunctions/vecNormalize.ts
+++ b/src/vecFunctions/vecNormalize.ts
@@ -9,8 +9,6 @@ import { vecReset } from "./vecReset";
  *
  * @param vec the vector to normalize
  * @param out
- * __see {@link vecGetLength}
- * __see {@link vecGetLengthSq}
  */
 export function vecNormalize(vec: Vec, out = vecAlloc()) {
   const lenSq = vec.x * vec.x + vec.y * vec.y;

--- a/src/vecFunctions/vecReset.ts
+++ b/src/vecFunctions/vecReset.ts
@@ -6,9 +6,6 @@ import { vecAlloc } from "./vecAlloc";
  * @param x x-coordinate of the vector
  * @param y y-coordinate of the vector
  * @param out
- * __see {@link IVec}
- * __see {@link vecAlloc}
- * __see {@link vecClone}
  */
 export function vecReset(x: number, y: number, out = vecAlloc()) {
   out.x = x;

--- a/src/vecFunctions/vecScale.ts
+++ b/src/vecFunctions/vecScale.ts
@@ -8,8 +8,6 @@ import { vecReset } from "./vecReset";
  * @param v the vector to scale
  * @param scalar the value by which the vector's components should be scaled
  * @param out
- * __see {@link vecAdd}
- * __see {@link vecTransformBy}
  */
 export function vecScale(v: Vec, scalar: number, out = vecAlloc()) {
   return vecReset(v.x * scalar, v.y * scalar, out);

--- a/src/vecFunctions/vecSubtract.ts
+++ b/src/vecFunctions/vecSubtract.ts
@@ -8,9 +8,6 @@ import { vecReset } from "./vecReset";
  * @param u the first vector
  * @param v the second vector
  * @param out
- * __see {@link vecAdd}
- * __see {@link vecScale}
- * __see {@link vecTransformBy}
  */
 export function vecSubtract(u: Vec, v: Vec, out = vecAlloc()) {
   return vecReset(u.x - v.x, u.y - v.y, out);

--- a/src/vecFunctions/vecTransformBy.ts
+++ b/src/vecFunctions/vecTransformBy.ts
@@ -19,8 +19,6 @@ import { vecReset } from "./vecReset";
  * @param v the vector to transform
  * @param mat the matrix to multiply this vector by
  * @param out
- * __see {@link Imat2d}
- * __see {@link vecAdd}
  */
 export function vecTransformBy(v: Vec, mat: Mat2d, out = vecAlloc()) {
   return vecReset(mat.a * v.x + mat.c * v.y + mat.tx, mat.b * v.x + mat.d * v.y + mat.ty, out);


### PR DESCRIPTION
Ultimately, they don't provide much value, and some of our tools (like `@wessberg/rollup-plugin-ts`) are choking on the newer supported syntax. Let's drop them until we have a thesis for their utility.