### PR TITLE
Loosen builtin epsilon values

### DIFF
--- a/src/internal/const.ts
+++ b/src/internal/const.ts
@@ -1,2 +1,2 @@
-export const EPSILON = 1e-8;
-export const EPSILON_SQ = 1e-16;
+export const EPSILON = 2 ** -16;
+export const EPSILON_SQ = 2 ** -32;


### PR DESCRIPTION
For most usages of the library, users are working in pixels, for which fractional values are already pretty meaningless. This PR expands the internal EPSILON to `2^-16 ≈ 0.0000152587890625`